### PR TITLE
Feature/mysql typeguessing

### DIFF
--- a/trunk/perl-modules/core/trunk/OpenXPKI/Server/DBI/Driver/MySQL.pm
+++ b/trunk/perl-modules/core/trunk/OpenXPKI/Server/DBI/Driver/MySQL.pm
@@ -22,6 +22,7 @@ our %TYPE = (
 
 our $DBI_OPTION = {
                    RaiseError => 0, 
+		   mysql_bind_type_guessing => 1,
                    AutoCommit => 0};
 
 our $TABLE_OPTION = "TYPE=InnoDB";


### PR DESCRIPTION
 This patch configures mysql_bind_type_guessing within OpenXPKI's MySQL.pm module.

background:

MySQL 5.1 stores DECIMAL values in binary format, before MySQL 5.0.3
DECIMAL values were stored as strings. Perl doesn't interpret DECIMALs
as integers unless Perl module DBI::Mysql is updated to >= 4.012 and
option mysql_bind_type_guessing is set.
