### PR TITLE
Add en_GB translations

### DIFF
--- a/core/i18n/en_GB/openxpki.po
+++ b/core/i18n/en_GB/openxpki.po
@@ -8,77 +8,82 @@ msgstr ""
 "Project-Id-Version: OpenXPKI 0.9\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2004-09-08 14:02+0200\n"
-"PO-Revision-Date: 2014-08-25 11:03+0100\n"
-"Last-Translator: OpenXPKI Team <i18n@openxpki.org>\n"
+"PO-Revision-Date: 2014-09-04 14:05+0100\n"
+"Last-Translator: Paweł Tomulik <ptomulik@meil.pw.edu.pl>\n"
 "Language-Team: OpenXPKI developers list <openxpki-devel@lists.sourceforge."
 "net>\n"
-"Language: \n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
+"X-Poedit-Bookmarks: -1,-1,77,-1,-1,-1,-1,-1,-1,-1\n"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_ACTION_UPDATE_METADATA"
-msgstr "Persist CSR"
+msgstr "Update metadata"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_ACTION_UPDATE_METADATA_ACTION"
-msgstr "Persist CSR"
+msgstr "I18N_OPENXPKI_ACTION_UPDATE_METADATA_ACTION"
 
 msgid "I18N_OPENXPKI_ACTIVITY_CSR_INSERTREQUEST_UNSUPPORTED_CSR_TYPE"
-msgstr "Unsupported request type"
+msgstr "Unsupported CSR type (__TYPE__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_ACTIVITY_PARSE_PKCS10_TT_DIED"
-msgstr "Sleep"
+msgstr ""
+"Template processing died when parsing PKCS10 (profile: __PROFILE__, style: "
+"__STYLE__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_ACTIVITY_SCEP_EXTRACT_CSR_NO_SUBJECT"
-msgstr "Change subject"
+msgstr "Missing subject in SCEP CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_ACTIVITY_SCEP_EXTRACT_CSR_RENDER_SUBJECT_FAILED"
 msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+"Failed to render CSR subject when processing SCEP CSR (profile: __PROFILE__, "
+"style: __STYLE__)"
 
 msgid "I18N_OPENXPKI_ANONYMOUS_USER"
 msgstr "Anonymous"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_ALIAS_BY_TYPE_NO_GROUP_FOUND"
-msgstr "testuser"
+msgstr ""
+"Token group not found for token type __TYPE__ (in call to OpenXPKI::Server::"
+"API::Token::get_token_alias_by_type())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_ALIAS_BY_TYPE_NO_TYPE_GIVEN"
-msgstr "reset"
+msgstr ""
+"Missing token type (in call to OpenXPKI::Server::API::Token::"
+"get_token_alias_by_type())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_GET_CA_LIST_TOKEN_STATUS_EVAL_ERROR"
-msgstr "Deutsch"
+msgstr ""
+"Evaluation error in OpenXPKI::Server::API::Token::get_ca_list() "
+"(I18N_OPENXPKI_API_TOKEN_GET_CA_LIST_TOKEN_STATUS_EVAL_ERROR)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_GET_CERTIFICATE_NOT_FOUND_FOR_ALIAS"
 msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+"Certificate not found for alias __ALIAS__ (in call to OpenXPKI::Server::API::"
+"Token::get_certificate_for_alias())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_GET_CERTIFICATE_NO_ALIAS_GIVEN"
-msgstr "uid"
+msgstr ""
+"Missing alias (in call to OpenXPKI::Server::API::Token::"
+"get_certificate_for_alias())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_GET_TOKEN_ALIAS_BY_GROUP_NO_GROUP"
-msgstr "Deutsch"
+msgstr ""
+"Missing group (in call to OpenXPKI::Server::API::Token::"
+"list_active_aliases())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_GET_TOKEN_ALIAS_BY_GROUP_NO_RESULT"
-msgstr "Deutsch"
+msgstr ""
+"Alias lookup returned no result in OpenXPKI::Server::API::Token::"
+"get_token_alias_by_group() (group: \"__GROUP__\", notbefore: \"__NOTBEFORE__"
+"\", notafter: \"__NOTAFTER__\", pki_realm: \"__PKI_REALM__\")"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_API_TOKEN_GET_TRUST_ANCHOR_NO_PATH"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr ""
+"Missing path (in call to OpenXPKI::Server::API::Token::get_trust_anchors())"
 
 msgid "I18N_OPENXPKI_APPROVAL_MESSAGE_CRR"
 msgstr ""
@@ -96,75 +101,87 @@ msgstr ""
 "SHA1-Hash of the session ID:\r\n"
 "__HASHSESSIONID__"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_BACKEND_OPENSSL_EVAL_ERROR"
-msgstr "Valid"
+msgstr ""
+"Evaluation error in OpenXPKI::Crypto::Backend::OpenSSL::__instantiate_cli "
+"(error: __ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_BACKEND_OPENSSL_INIT_ENGINE_NEW_FAILED"
-msgstr "Microsoft Internet Explorer"
+msgstr ""
+"$engine->new() failed in OpenXPKI::Crypto::Backend::OpenSSL::"
+"__instantiate_engine()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_BACKEND_OPENSSL_INSTANTIATE_CLI_FAILED"
-msgstr "Trustcenter Web Interface"
+msgstr "OpenXPKI::Crypto::Backend::OpenSSL::__init_cli() failed"
 
-#, fuzzy
+# Delete this!!!
 msgid "I18N_OPENXPKI_CERT_"
-msgstr "Authority Information Access"
+msgstr "This message should never be displayed. Please delete the translation."
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_AUTH_STACK_ENTER_ID"
-msgstr "Choose authentication method"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_AUTH_STACK_ENTER_ID"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_AUTH_STACK_WRONG_ID"
-msgstr "hide"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_AUTH_STACK_WRONG_ID"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_AUTH_STACK_MESSAGE"
-msgstr "Choose authentication method"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_AUTH_STACK_MESSAGE"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_PKI_REALM_ENTER_ID"
-msgstr "Choose a PKI realm"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_PKI_REALM_ENTER_ID"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_PKI_REALM_MESSAGE"
-msgstr "Choose a PKI realm"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_PKI_REALM_MESSAGE"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_PKI_REALM_WRONG_ID"
-msgstr "Choose a PKI realm"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_GET_PKI_REALM_WRONG_ID"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_PASSWD_LOGIN_FAILED"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_PASSWD_LOGIN_FAILED"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_PKI_REALM_INFINITE_LOOP_DETECTED"
-msgstr "PKI realm __PKI_REALM__"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_PKI_REALM_INFINITE_LOOP_DETECTED"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_PKI_REALM_LIST_FAILED"
-msgstr "Choose a PKI realm"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_PKI_REALM_LIST_FAILED"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_AUTH_LIST_FAILED"
-msgstr "Certificate search result"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_AUTH_LIST_FAILED"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_INFINITE_LOOP_DETECTED"
-msgstr "Certificate #__SERIAL__"
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_INFINITE_LOOP_DETECTED"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_UNEXPECTED_MESSAGE"
-msgstr "Please choose one of the menu entries to create a new request."
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_UNEXPECTED_MESSAGE"
 
+# Should probably be deleted. It appears only in a commented-out block of code.
 #, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_UNSUPPORTED_SERVICE_MSG"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CLIENT_CLI_INIT_USER_UNSUPPORTED_SERVICE_MSG"
 
 msgid "I18N_OPENXPKI_CLIENT_COLLECT_EVAL_ERROR"
 msgstr ""
@@ -174,62 +191,59 @@ msgstr ""
 msgid "I18N_OPENXPKI_CLIENT_COLLECT_TIMEOUT"
 msgstr "A timeout occured while reading data from the CA server."
 
-#, fuzzy
+# Is this a kind of "internal error"?
 msgid "I18N_OPENXPKI_CLIENT_INCORRECT_COMMUNICATION_STATE"
-msgstr "A timeout occured while reading data from the CA server."
+msgstr ""
+"Incorrect communication status in OpenXPI::Client::talk() (status: "
+"__STATUS__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_INIT_CONNECTION_FAILED"
-msgstr "Deutsch"
+msgstr ""
+"Failed to initialize connection in OpenXPKI::Client::__init_connection  "
+"(socket file: __SOCKETFILE__, error: __ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_INIT_CONNECTION_NO_SOCKET"
-msgstr "Tickets"
+msgstr "Missing socket in call to OpenXPI::Client::__init_connection()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_INIT_SERIALIZATION_PROTOCOL_REJECTED"
-msgstr "reset"
+msgstr ""
+"Serialization protocol rejected (in OpenXPKI::Client::"
+"__init_serialization_protocol())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_INIT_SERVICE_PROTOCOL_REJECTED"
 msgstr ""
-"Downloading the private key failed. Are you sure you have entered the "
-"correct password?"
+"Service protocol rejected (in OpenXPKI::Client::__init_service_protocol())"
 
 msgid "I18N_OPENXPKI_CLIENT_INIT_SESSION_FAILED"
 msgstr "Failed to start session"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_INIT_TRANSPORT_PROTOCOL_REJECTED"
-msgstr "Reset"
+msgstr ""
+"Transport protocol rejected (in OpenXPKI::Client:__init_transport_protocol())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_SCEP_INVALID_OP"
-msgstr "SPKAC"
+msgstr "Invalid operation (in OpenXPKI::Client::SCEP::send_request())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_SEND_RECEIVE_SERVICE_MSG_ERROR_DURING_COLLECT"
-msgstr "Errors"
+msgstr ""
+"collect() failed in OpenXPKI::Client::send_receive_service_msg() (error: "
+"__EVAL_ERROR__, state: __STATE__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_SEND_RECEIVE_SERVICE_MSG_ERROR_DURING_SEND_SERVICE_MSG"
 msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+"send_receive_msg() failed in OpenXPKI::Client::send_receive_service_msg() "
+"(error: __EVAL_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_SEND_SERVICE_MSG_TALK_FAILED"
 msgstr ""
-"Downloading the private key failed. Are you sure you have entered the "
-"correct password?"
+"talk() failed in OpenXPKI::Client::send_service_msg() (error: __EVAL_ERROR__)"
 
-#, fuzzy
+# This should probably be deleted. It appears only in a commented-out block of code
 msgid "I18N_OPENXPKI_CLIENT_SIGNAL_CAUGHT"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_CLIENT_SIGNAL_CAUGHT"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CLIENT_TALK_ERROR_DURING_WRITE"
-msgstr "Trustcenter Web Interface"
+msgstr "write() failed in OpenXPKI::Client::talk() (error: __EVAL_ERROR__)"
 
 msgid "I18N_OPENXPKI_CN_DESC"
 msgstr "Common Name"
@@ -264,12 +278,8 @@ msgstr ""
 "Login using IE or Mozilla-based browser by signing a challenge with your "
 "certificate and private key."
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CONFIG_AUTH_HANDLER_DESCRIPTION_USER"
-msgstr ""
-"Here we use an external program to authenticate you. Simply enter your "
-"normal account and passphrase. All other stuff will be done automatically in "
-"the background."
+msgstr "User without authentication (any password accepted)"
 
 msgid "I18N_OPENXPKI_CONFIG_AUTH_STACK_DESCRIPTION_ANONYMOUS"
 msgstr ""
@@ -302,131 +312,124 @@ msgstr "This is the normal user authentication."
 msgid "I18N_OPENXPKI_CONFIG_DEFAULT_SECRET_AUTHENTICATION_GROUP"
 msgstr "Default key group"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_API_CHECK_COMMAND_PARAM_PARAM_PATH_MISMATCH"
-msgstr "Common name"
+msgstr ""
+"Parameter mismatch in OpenXPKI::Crypto::API::__check_command_param() (param: "
+"__PARAM__, param_path: __PARAM_PATH__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_API_COMMAND_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr ""
+"Illegal parameter for command __COMMAND__ (command path: __COMMAND_PATH__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_API_COMMAND_NO_COMMAND_PARAMS"
-msgstr "Common name"
+msgstr ""
+"Missing command parameters (in OpenXPKI::Crypto::API::"
+"__check_command_param())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_API_COMMAND_NO_COMMAND_SPECIFIED"
-msgstr "The used suject style does not allow the use of a country."
+msgstr ""
+"No command specified in call to OpenXPKI::Crypto::API::"
+"__check_command_param()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_API_EVAL_ERROR"
-msgstr "Valid"
+msgstr ""
+"Evaluation error in OpenXPKI::Crypto::API::START() (error: __error_message__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_API_IS_ABSTRACT_CLASS"
-msgstr "Test User CA"
+msgstr "Instantiation of abstract class OpenXPKI::Crypto::API is not allowed"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_API_NEW_MISSING_CLASS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing class in call to OpenXPKI::Crypto::API::START()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_COMMAND_ILLEGAL_VALUE"
-msgstr "Common name"
+msgstr ""
+"Illegal value \"__VALUE__\" for command __COMMAND__ (with parameter: "
+"__PARAM__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_COMMAND_WRONG_CONFIG"
-msgstr "The used suject style does not allow the use of a country."
+msgstr ""
+"Configuration check failed, the config must be wrong (command: __COMMAND__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_FREE_OBJECT_NOT_IN_CACHE"
-msgstr "Common name"
+msgstr ""
+"OpenXPKI::Crypto::Backend::API::free() has been requested to free an object "
+"which is not in cache"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_FREE_OBJECT_NO_REF"
-msgstr "Common name"
+msgstr ""
+"The provided argument is not an object reference (in call to OpenXPKI::"
+"Crypto::Backend::API::free())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_CERTFILE_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr "Illegal parameter (in call to OpenXPKI::Crypto::API::get_certfile())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_FUNCTION_ILLEGAL_FUNCTION"
-msgstr "Common name"
+msgstr ""
+"Illegal function __FUNCTION__ for object type __TYPE__ (in call to OpenXPKI::"
+"Crypto::Backend::API::get_object_function())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_FUNCTION_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr ""
+"Illegal parameter __NAME__ (with value: __VALUE__) in call to OpenXPKI::"
+"Crypto::Backend::API::get_object_function()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_FUNCTION_OBJECT_NOT_IN_CACHE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr ""
+"OpenXPKI::Crypto::Backend::API::get_object_function() has been requested to "
+"perform an operation on an object which is not in cache"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_FUNCTION_OBJECT_NO_REF"
-msgstr "Common name"
+msgstr ""
+"The provided parameter is not an object reference (in call to OpenXPKI::"
+"Crypto::Backend::API::get_object_function())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_ILLEGAL_FORMAT"
-msgstr "Common name"
+msgstr "Illegal object format (type: __TYPE__, format: __FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr ""
+"Illegal parameter __NAME__ (with value: __VALUE__) in call to OpenXPKI::"
+"Crypto::Backend::API::get_object()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_ILLEGAL_TYPE"
-msgstr "Common name"
+msgstr ""
+"Illegal object type __TYPE__ in call to OpenXPKI::Crypto::Backend::API::"
+"get_object()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_GET_OBJECT_MISSING_DATA"
-msgstr "Common name"
+msgstr "Missing data in call to OpenXPKI::Crypto::Backend::API::get_object()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_KEY_USABLE_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr "Illegal parameter in call to OpenXPKI::Crypto::API::key_usable()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_LOGIN_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr "Illegal parameter in call to OpenXPKI::Crypto::API::login()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_LOGOUT_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr "Illegal parameter in call to OpenXPKI::Crypto::API::logout()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_NEW_ILLEGAL_PARAMETER"
-msgstr "Common name"
+msgstr ""
+"Illegal parameter __NAME__ (with value: __VALUE__) provided to OpenXPKI::"
+"Crypto::Backend::API::START"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_NEW_MISSING_NAME"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing name in call to OpenXPKI::Crypto::Backend::API::START"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_NEW_MISSING_TOKEN_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing token type in call to OpenXPKI::Crypto::Backend::API::START"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_API_ONLINE_ILLEGAL_PARAM"
-msgstr "Common name"
+msgstr "Illegal parameter in call to OpenXPKI::Crypto::API::online()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_OPENSSL_COMMAND_CREATE_KEY_UNSUPPORTED_TYPE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Unsupported key type __TYPE__"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_OPENSSL_COMMAND_CREATE_PKCS12_CSP_IS_NOT_ALPHANUMERIC"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS12 CSP is not alphanumeric (CSP: \"__CSP__\")"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_OPENSSL_COMMAND_PKCS7_GET_CHAIN_COULD_NOT_CREATE_CHAIN"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Could not create certificate chain (PKCS7)"
 
 msgid "I18N_OPENXPKI_CRYPTO_BACKEND_OPENSSL_CONFIG_MD5_DIGEST_BROKEN"
 msgstr ""
@@ -434,997 +437,889 @@ msgstr ""
 "signature. MD5 has been broken both theoretically and practically and should "
 "no longer be used. This is why OpenXPKI prevents you from signing with MD5."
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_CANNOT_OPEN_ERRLOG"
-msgstr "reset"
+msgstr "Can not open error log (__FILENAME__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_ERROR"
-msgstr "Valid"
+msgstr "Error detected (error code: __ERRVAL__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_EXECUTE_FAILED"
-msgstr "CSR with DC-style"
+msgstr "OpenXPKI::Crypto::CLI::execute() failed (exit status: __EXIT_STATUS__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_EXECUTE_PIPED_STDIN_FAILED"
-msgstr "CSR with DC-style"
+msgstr ""
+"OpenXPKI::Crypto::CLI::execute() failed (piped stdin, exit status: "
+"__EXIT_STATUS__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_EXECUTE_PIPED_STDOUT_FAILED"
-msgstr "CSR with DC-style"
+msgstr ""
+"OpenXPKI::Crypto::CLI::execute() failed (piped stdout, exit status: "
+"__EXIT_STATUS__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_EXECUTE_WAIT_FAILED"
-msgstr "CSR with DC-style"
+msgstr ""
+"OpenXPKI::Crypto::CLI::execute() failed (wait() failed, error value: "
+"__ERROR_VALUE__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_IS_ABSTRACT_CLASS"
-msgstr "New Request (CSR)"
+msgstr "Instantiation of abstract class OpenXPKI::Crypto::CLI: is not allowed"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_MISSING_ENGINE"
-msgstr "reset"
+msgstr "Missing ENGINE in call to OpenXPKI::Crypto::CLI::START"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_MISSING_SHELL"
-msgstr "reset"
+msgstr "Missing SHELL in call to OpenXPKI::Crypto::CLI::START"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_MISSING_TMP"
-msgstr "SPKAC"
+msgstr "Missing TMP in call to OpenXPKI::Crypto::CLI::START"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CLI_TMP_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "The temporary \"__TMP__\" does not exist or is not a directory"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CRL_GET_CONVERTED_MISSING_FORMAT"
-msgstr "SPKAC"
+msgstr "Missing CRL format in call to OpenXPKI::Crypto::CRL::get_converted()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CRL_GET_CONVERTED_WRONG_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Wrong CRL format (__FORMAT__) in call to OpenXPKI::Crypto::CRL::"
+"get_converted()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CRL_NEW_MISSING_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing data in call to OpenXPKI::Crypto::CRL::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CRL_NEW_MISSING_TOKEN"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing token in call to OpenXPKI::Crypto::CRL::new"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CRR_NEW_MISSING_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing data in call to OpenXPKI::Crypto::CRR::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CSR_GET_CONVERTED_MISSING_FORMAT"
-msgstr "SPKAC"
+msgstr "Missing CSR format in call to OpenXPKI::Crypto::CSR::get_converted()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CSR_GET_CONVERTED_SPKAC_DETECTED"
-msgstr "SPKAC"
+msgstr "SPKAC detected"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CSR_GET_CONVERTED_WRONG_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Wrong CSR format (__FORMAT__) in call to OpenXPKI::Crypto::CSR::"
+"get_converted()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CSR_GET_INFO_HASH_EVAL_OF_DUMP_FAILED"
-msgstr "Choose authentication method"
+msgstr ""
+"Dumper failed (error: __EVAL_ERROR) in OpenXPKI::Crypto::CSR::get_info_hash()"
 
-#, fuzzy
+# This should be probably removed. It appears only in a commented-out block of code.
 msgid "I18N_OPENXPKI_CRYPTO_CSR_INIT_MISSING_SUBJECT"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_CRYPTO_CSR_INIT_MISSING_SUBJECT"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CSR_NEW_MISSING_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing DATA in call to OpenXPKI::Crypto::CSR::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CSR_NEW_MISSING_TOKEN"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Missing TOKEN in call to OpenXPKI::Crypto::CSR::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_CSR_NEW_WRONG_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Wrong CSR type (__TYPE__) in call to OpenXPKI::Crypto::CSR::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OBJECT_GET_PARSED_NO_VALUE"
-msgstr "CSR with DC-style"
+msgstr ""
+"Missing value (PARSED) in call to OpenXPKI::Crypto::Object::get_parsed()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OBJECT_SET_HEADER_ATTRIBUTE_REINIT_FAILED"
-msgstr "Choose authentication method"
+msgstr ""
+"Reinitialization failed  in OpenXPKI::Crypto::Object::get_header_attribute()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CLEANUP_ENV_FAILED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"OpenXPKI::Crypto::Backend::OpenSSL::Command::cleanup() failed (environment "
+"variable $__VARIABLE__ does not exist)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CLEANUP_FILE_FAILED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"OpenXPKI::Crypto::Backend::OpenSSL::Command::cleanup() failed (file __FILE__ "
+"does not exist)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CERT_ILLEGAL_CONTAINER_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Certificate conversion error (illegal container format: __CONTAINER_FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CERT_MISSING_DATA"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Certificate conversion error (missing DATA)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CERT_MISSING_OUTPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Certificate conversion failed (missing OUTPUT FORMAT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CERT_WRONG_DATATYPE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Certificate conversion failed (wrong DATA TYPE)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CRL_DATA_EMPTY"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "CRL conversion failed (empty DATA)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CRL_MISSING_DATA"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "CRL conversion failed (missing DATA)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CRL_MISSING_OUTPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "CRL conversion failed (missing OUTPUT FORMAT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CRL_WRONG_OUTPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "CRL conversion failed (wrong OUTPUT FORMAT: __OUTPUT_FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_MISSING_DATA"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key conversion failed (missing DATA)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_MISSING_INPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key conversion failed (missing INPUT FORMAT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_MISSING_OUTPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key conversion failed (missing OUTPUT FORMAT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key conversion failed (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_ENC_ALG"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key conversion failed (wrong ENCRYPTION ALGORITHM: __ENC_ALG__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_INPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key conversion failed (wrong INPUT FORMAT: __INPUT_FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_OUTPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key conversion failed (wrong OUTPUT FORMAT: __OUTPUT_FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_PKCS10_INCORRECT_INPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 conversion failed (incorrect INPUT FORMAT: __FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_PKCS10_MISSING_DATA"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 conversion failed (missing DATA)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_PKCS10_MISSING_OUTPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 conversion failds (missing OUTPUT FORMAT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_PKCS10_WRONG_OUTPUT_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 conversion failed (wrong OUTPU FORMAT: __OUTPUT_FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 conversion failed (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_NO_ENGINE_FOR_GOST"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key creation failed (no engine for gost)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_EC_CURVE_NAME"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key creation failed (wrong EC CURVE NAME: __EC_CURVE_NAME__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key creation failed (wrong ENCRYPTION ALGORITHM: __ENC_ALG__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_KEY_LENGTH"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Key creation failed (wrong KEY LENGTH: __KEY_LENGTH__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PARAMS_MISSING_TYPE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Missing TYPE in call to OpenXPKI::Crypto::Backend::OpenSSL::Command::"
+"create_params::get_command()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS10_MISSING_KEY"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 creation failed (missing KEY)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS10_MISSING_KEYFILE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 creation failed (missing KEYFILE)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS10_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 creation failed (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS10_MISSING_SUBJECT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS10 creation failed (missing SUBJECT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS12_EMPTY_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS12 creation failed (missing EMPTY PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS12_MISSING_CERT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS12 creation failed (missing CERTIFICATE)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS12_MISSING_KEY"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS12 creation failed (missing KEY)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS12_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS12 creation failed (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKCS12_PASSWD_TOO_SHORT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "PKCS12 creation failed (PASSWORD too short)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKEY_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to generate private key (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKEY_PKEYOPT_IS_NOT_HASH"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to generate private key (PKEYOPT is not a hash)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_PKEY_REQUIRE_KEY_ALG_OR_PARAM"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failed to generate private key (private key requires KEY ALGORITM or PARAM)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_RANDOM_EMPTY"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to generate private key (RANDOM seed is empty)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_RANDOM_MISSING_LENGTH"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Random seed creation failed (missing LENGTH)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_RSA_WRONG_ENC_ALG"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failed to generate RSA  PKCS12 (wrong ENCRYPTION ALGORITHM: __ENC_ALG__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_DN_FAILURE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "DN failure in OpenXPKI::Crypto::Backend::OpenSSL::Command (DN: __DN__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_GET_PKCS8_KEYTYPE_MISSING_DATA"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to get PKCS8 key type (missing DATA)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_GET_PKCS8_KEYTYPE_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to get PKCS8 key type (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CERT_KEYFILE_DOES_NOT_EXIST"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to issue certificate (KEY file does not exist: __KEYFILE__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CERT_MISSING_CSRFILE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to issue certificate (missing CSR file name)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CERT_MISSING_KEYFILE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to issue certificate (missing KEY FILE name)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CERT_MISSING_PROFILE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to issue cerificate (missing PROFILE)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CRL_KEYFILE_DOES_NOT_EXIST"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to issue CRL (KEY FILE does not exist: __KEYFILE__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CRL_MISSING_KEYFILE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to issue CRL (missing KEY FILE name)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CRL_MISSING_PROFILE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to issue CRL (missing PROFILE)"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CRL_REVOKED_CERT_FAILED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CRL_REVOKED_CERT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_IS_PRIME_MISSING_PRIME"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_IS_PRIME_MISSING_PRIME"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_LIST_ALGS_ILLEGAL_FORMAT"
-msgstr "Common name"
+msgstr "Failed to list encryption algorithms (illegal FORMAT: __FORMAT__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_LIST_ALGS_NO_ALGORITMN"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to list encryption algorithms (no ALGORITHM)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_LIST_ALGS_NO_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to list encryption algorithms (missing FORMAT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_LIST_ALGS_NO_PARAM_NAME"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to list encryption algorithms (no PARAM NAME)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_LIST_ALGS_UNSUPPORTED_ALGORITHM"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to list encryption algorithms (unsupported ALGORITHM: __ALG__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_LIST_ALGS_UNSUPPORTED_PARAM_NAME"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failed to list encryption algorithms (unsupported PARAM NAME: __PARAM__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_MISSING_CONFIG"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Missing CONFIG in call to OpenXPKI::Crypto::Backend::OpenSSL::Command::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_MISSING_ENGINE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Missing ENGINE in call to OpenXPKI::Crypto::Backend::OpenSSL::Command::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_MISSING_XS"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Missing XS in call to OpenXPKI::Crypto::Backend::OpenSSL::Command::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_DECRYPT_MISSING_CERT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to decrypt PKCS7 (missing CERTIFICATE)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_DECRYPT_MISSING_CERTFILE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to decrypt PKCS7 (missing CERTIFICATE FILE name)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_DECRYPT_MISSING_KEY"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to decrypt PKCS7 (missing KEY)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_DECRYPT_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to decrypt PKCS7 (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_DECRYPT_MISSING_PKCS7"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to decrypt PKCS7 (missing PKCS7)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_ENCRYPT_MISSING_CERT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to encrypt PKCS7 (missing CERTIFICATE)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_ENCRYPT_MISSING_CONTENT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to encrypt PKCS7 (missing CONTENT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_ENCRYPT_WRONG_ENC_ALG"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to encrypt PKCS7 (wrong ENCRYPTION ALGORITHM: __ENC_ALG__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_GET_CHAIN_MISSING_PKCS7"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to get PKCS7 chain (missing PKCS7)"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_GET_END_ENTITY_MULTIPLE_SAME_SUBJECTS_WITH_DIFFERENT_DATA"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_GET_END_ENTITY_MULTIPLE_SAME_SUBJECTS_WITH_DIFFERENT_DATA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_GET_END_ENTITY_UNABLE_TOO_DETECT_CORRECT_END_ENTITY_CERTIFICATE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_GET_END_ENTITY_UNABLE_TOO_DETECT_CORRECT_END_ENTITY_CERTIFICATE"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_SIGN_MISSING_CERT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to sign PKGS7 (missing CERTIFICATE)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_SIGN_MISSING_CONTENT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to sign PKCS7 (missing CONTENT)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_SIGN_MISSING_KEY"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to sign PKCS7 (missing KEY)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_SIGN_MISSING_PASSWD"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to sign PKCS7 (missing PASSWORD)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_VERIFY_MISSING_CHAIN"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to verify PKCS7 (missing CHAIN)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_VERIFY_MISSING_PKCS7"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to verify PKCS7 (missing PKCS7)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_TEMPORARY_DIRECTORY_UNAVAILABLE"
-msgstr "Trustcenter Web Interface"
+msgstr ""
+"Temporary directory unavailable (in OpenXPKI::Crypto::Backend::OpenSSL::"
+"Command::New())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_VERIFY_CERT_MISSING_CERTIFICATE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to verify certificate (CERTIFICATE is missing)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_WRITE_CONFIG_UNKNOWN_NAMED_EXTENSION"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to write config (unknown named extension __NAME__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_CONFIG_DUMP_WRONG_SERIAL"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Failed to dump configuration (wrong serial)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_CONFIG_MISSING_XS"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Missing CONFIG in call to OpenXPKI::Crypto::Backend::OpenSSL::Config::new()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_CONFIG_TEMPORARY_DIRECTORY_UNAVAILABLE"
-msgstr "Trustcenter Web Interface"
+msgstr ""
+"Temporary directory unavailable (in OpenXPKI::Crypto::Backend::OpenSSL::"
+"Config::New())"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_GET_PASSWD_UNDEF"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failed to retrieve password in OpenXPKI::Crypto::Backend::OpenSSL::Engine::"
+"get_password() (password undefined)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_GETKEYHASH_COMMAND_INVOCATION_ERROR"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occurred OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"__getKeyHash() (__CHILD_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_GETKEYHASH_COMMAND_INVOCATION_FAILED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occurred in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"__getKeyHash() (failed to invoke command __COMMAND__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_GETKEYHASH_COMMAND_INVOCATION_TIMEOUT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occurred in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"__getKeyHash() (command timed out)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_GETKEYHASH_COMMAND_INVOCATION_UNEXPECTED_EXCEPTION"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occurred in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"_getKeyHash() (unexpected exception: __EVAL_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_INVALID_VALUE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Invalid value __VALUE__ for parameter __PARAMETER__"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_COMMAND_INVOCATION_ERROR"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occurred in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"key_usable() (__CHILD_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_COMMAND_INVOCATION_TIMEOUT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occurred in  OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"key_usable() (command invocation timeout)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_COMMAND_INVOCATION_UNEXPECTED_EXCEPTION"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Unexpected exception in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"key_usable() (__EVAL_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_EXEC_NFKMINFO_COMMAND_ERROR"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Could no run 'nfkminfo' command in OpenXPKI::Crypto::Backend::OpenSSL::"
+"Engine::nCipher::key_usable() (__EVAL_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_NO_PRELOADED_OBJECTS_FOUND"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"No preloaded objects found in OpenXPKI::Crypto::Backend::OpenSSL::Engine::"
+"nCipher::key_usable()"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_OBJECT_NOT_PRELOADED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Object __OCSHASH__ is not preloaded, key is not usable"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_SECURITY_WORLD_NOT_INITIALIZED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Error in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::key_usable() "
+"(security world is not initialized)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_KEY_USABLE_SECURITY_WORLD_NOT_USABLE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Error in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::key_usable() "
+"(security world is not usable)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_NFAST_HOME_NOT_ACCESSIBLE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"__NFAST_HOME__ is not accessible (not a directory or is missing 'x' "
+"attribute)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_ONLINE_COMMAND_INVOCATION_ERROR"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Command invocation error occurred in OpenXPKI::Crypto::Backend::OpenSSL::"
+"Engine::nCipher::online() (__CHILD_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_ONLINE_COMMAND_INVOCATION_FAILED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occured in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"online() (failed to invoke command __COMMAND__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_ONLINE_COMMAND_INVOCATION_TIMEOUT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Failure occurred in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"online() (command invocation timeout)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_ONLINE_COMMAND_INVOCATION_UNEXPECTED_EXCEPTION"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr ""
+"Unexpected exception in OpenXPKI::Crypto::Backend::OpenSSL::Engine::nCipher::"
+"online() (__CHILD_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_ONLINE_HARDSERVER_NOT_OPERATIONAL"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "nCipher hardserver process is not operational"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_NCIPHER_ONLINE_NO_OPERATIONAL_MODULES_ONLINE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "No operational nCipher modules are online"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_OPENSSL_LOGIN_FAILED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Login failed"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_OPENSSL_LOGIN_FAILED_EVAL_ERROR"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Login failed (__EVAL_ERROR__)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_OPENSSL_LOGIN_INCOMPLETE_SECRET"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Login failed (incomplete SECRET)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_OPENSSL_LOGIN_PASSWD_TOO_SHORT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "Password too short"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_WRONG_ENGINE_USAGE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_WRONG_ENGINE_USAGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_WRONG_KEY_STORE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_WRONG_KEY_STORE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_WRONG_NEVER_ENGINE_USAGE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_ENGINE_WRONG_NEVER_ENGINE_USAGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_GET_OBJECT_FUNCTION_DATE_PARSING_ERROR"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_GET_OBJECT_FUNCTION_DATE_PARSING_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_GET_OBJECT_NO_REF"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_GET_OBJECT_NO_REF"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_OPENSSL_GET_OBJECT_UNKNOWN_TYPE"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_OPENSSL_GET_OBJECT_UNKNOWN_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_BASE_AUTOLOAD_ILLEGAL_FUNCTION"
-msgstr "Basic user naming style"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_BASE_AUTOLOAD_ILLEGAL_FUNCTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_BASE_ERROR_PARSING_TEMPLATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_BASE_ERROR_PARSING_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_COPY_EXTENSION_INVALID_VALUE"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_COPY_EXTENSION_INVALID_VALUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_GET_EXTENSION_NOT_FOUND"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_GET_EXTENSION_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_GET_SUBJECT_NOT_PRESENT"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_GET_SUBJECT_NOT_PRESENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_IS_CIRITICAL_EXTENSION_NOT_FOUND"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_IS_CIRITICAL_EXTENSION_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_LOAD_EXTENSION_UNKNOWN_NAME"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_LOAD_EXTENSION_UNKNOWN_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_LOAD_PROFILE_UNDEFINED_PROFILE"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_LOAD_PROFILE_UNDEFINED_PROFILE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_LOAD_PROFILE_VALIDITY_NOTAFTER_NOT_DEFINED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_LOAD_PROFILE_VALIDITY_NOTAFTER_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_NEW_INCORRECT_TYPE"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_NEW_INCORRECT_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_NEW_MISSING_CA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_NEW_MISSING_CA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_NEW_MISSING_ID"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_NEW_MISSING_ID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_CRITICALITY_NOT_SPECIFIED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_CRITICALITY_NOT_SPECIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_INVALID_CRITICALITY"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_INVALID_CRITICALITY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_NAME_NOT_SPECIFIED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_NAME_NOT_SPECIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_VALUE_NOT_SPECIFIED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CERTIFICATE_SET_EXTENSION_VALUE_NOT_SPECIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CRL_LOAD_PROFILE_INVALID_VALIDITY_FORMAT"
-msgstr "Invalid parameter for plain password authentication."
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CRL_LOAD_PROFILE_INVALID_VALIDITY_FORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CRL_LOAD_PROFILE_VALIDITY_NOTAFTER_NOT_DEFINED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CRL_LOAD_PROFILE_VALIDITY_NOTAFTER_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_PROFILE_CRL_NEW_MISSING_CA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CRYPTO_PROFILE_CRL_NEW_MISSING_CA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_IMPLEMENTATION_UNAVAILABLE"
-msgstr "Choose authentication method"
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_IMPLEMENTATION_UNAVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_INSTANTIATION_FAILED"
-msgstr "Choose authentication method"
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_INSTANTIATION_FAILED"
 
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_PLAIN_INVALID_PARAMETER"
 msgstr "Invalid parameter for plain password authentication."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_PLAIN_MISSING_PARAMETER"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_PLAIN_MISSING_PARAMETER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_SPIT_N_OR_K_MISSING"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_SPIT_N_OR_K_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_EMPTY_SHARE"
-msgstr "New Request (CSR)"
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_EMPTY_SHARE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_INVALID_SHARE_VERSION"
-msgstr ""
-"DC-style means the we use domain components at the of the certificates name. "
-"An old style DN looks like this: cn=John Doe, o=OpenXPKI, c=DE. The last "
-"attribute c only accepts two letters and no domain names. The same thing "
-"with the new DC-style looks like this: cn=John Doe, dc=OpenXPKI, dc=DE. The "
-"advantage is that we can use now the more correct name: cn=John Doe, "
-"dc=OpenXPKI, dc=org. We have no longer to use a country."
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_INVALID_SHARE_VERSION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_NOT_YET_IMPLEMENTED"
-msgstr "New Request (CSR)"
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_NOT_YET_IMPLEMENTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_QUORUM_MISSING"
-msgstr "CSR with OU-style"
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_QUORUM_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_TOKEN_MISSING"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_TOKEN_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_WRONG_CHECKSUM"
-msgstr "The email address __EMAIL__ is not a valid RFC 822 address."
+msgstr "I18N_OPENXPKI_CRYPTO_SECRET_SPLIT_WRONG_CHECKSUM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_CREATE_FAILED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_CREATE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_EVAL_ERROR"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_EVAL_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_INIT_FAILED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_INIT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_NO_BACKEND_CLASS"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_ADD_TOKEN_NO_BACKEND_CLASS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_SYSTEM_TOKEN_MISSING_TYPE"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_SYSTEM_TOKEN_MISSING_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_SYSTEM_TOKEN_UNKNOWN_TYPE"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_SYSTEM_TOKEN_UNKNOWN_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_MISSING_NAME"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_MISSING_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_MISSING_PKI_REALM"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_MISSING_PKI_REALM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_MISSING_TYPE"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_MISSING_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_NOT_EXIST"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_NOT_USABLE"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_GET_TOKEN_NOT_USABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_INSTANTIATION_OUTSIDE_SERVER_INIT"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_INSTANTIATION_OUTSIDE_SERVER_INIT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_LOAD_SECRET_MISSING_GROUP"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_LOAD_SECRET_MISSING_GROUP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_LOAD_SECRET_WRONG_CACHE_TYPE"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_LOAD_SECRET_WRONG_CACHE_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_LOAD_SECRET_WRONG_METHOD"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_LOAD_SECRET_WRONG_METHOD"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_USE_TOKEN_NOT_PRESENT"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_CRYPTO_TOKENMANAGER_USE_TOKEN_NOT_PRESENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOLKIT_CANT_BUILD_KEY_PATH"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_CRYPTO_TOOLKIT_CANT_BUILD_KEY_PATH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOLKIT_CERTIFICATE_NOT_DEFINED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_CRYPTO_TOOLKIT_CERTIFICATE_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOLKIT_INCOMPLETE_CONFIGURATION"
-msgstr ""
-"A domain component is a part of a name from the domain name system (DNS). If "
-"you have a server www.openxpki.org then the domain components are www, "
-"openxpki and org. If you can only enter one component then it must be "
-"usually the last one."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOLKIT_INCOMPLETE_CONFIGURATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOLKIT_INCOMPLETE_CONFIGURATION_NO_BACKEND"
-msgstr ""
-"A domain component is a part of a name from the domain name system (DNS). If "
-"you have a server www.openxpki.org then the domain components are www, "
-"openxpki and org. If you can only enter one component then it must be "
-"usually the last one."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOLKIT_INCOMPLETE_CONFIGURATION_NO_BACKEND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOLKIT_IS_ABSTRACT_CLASS"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_CRYPTO_TOOLKIT_IS_ABSTRACT_CLASS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_MAKEJAVAKEYSTORE_COMMAND_CREATE_KEYSTORE_COULD_NOT_GET_CERTIFICATE_ARRAY"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_MAKEJAVAKEYSTORE_COMMAND_CREATE_KEYSTORE_COULD_NOT_GET_CERTIFICATE_ARRAY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_CERTFILE_MISSING"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_CERTFILE_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_INVALID_ERROR_CODE"
-msgstr "Errors"
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_INVALID_ERROR_CODE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_KEYFILE_MISSING"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_KEYFILE_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_NO_ENGINE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_ERROR_REPLY_NO_ENGINE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_NEXTCA_REPLY_CERTFILE_MISSING"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_NEXTCA_REPLY_CERTFILE_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_NEXTCA_REPLY_KEYFILE_MISSING"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_NEXTCA_REPLY_KEYFILE_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_NEXTCA_REPLY_NO_ENGINE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_NEXTCA_REPLY_NO_ENGINE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_PENDING_REPLY_CERTFILE_MISSING"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_PENDING_REPLY_CERTFILE_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_PENDING_REPLY_KEYFILE_MISSING"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_PENDING_REPLY_KEYFILE_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_PENDING_REPLY_NO_ENGINE"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_TOOL_SCEP_COMMAND_CREATE_PENDING_REPLY_NO_ENGINE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_CAN_DECRYPT_MISSING_ARGUMENT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_CAN_DECRYPT_MISSING_ARGUMENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_COMPUTE_KEY_ID_MISSING_PARAMETERS"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_COMPUTE_KEY_ID_MISSING_PARAMETERS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_DECRYPT_INVALID_ENCRYPTED_DATA"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_DECRYPT_INVALID_ENCRYPTED_DATA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_DECRYPT_INVALID_VAULT_INSTANCE"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_DECRYPT_INVALID_VAULT_INSTANCE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_ENCRYPT_INVALID_ENCODING"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_ENCRYPT_INVALID_ENCODING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_ENCRYPT_INVALID_PARAMETER"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_ENCRYPT_INVALID_PARAMETER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_EXPORT_KEY_DENIED"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_EXPORT_KEY_DENIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INITIALIZATION_ERROR"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INITIALIZATION_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INVALID_EXPORTABLE_SETTING"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INVALID_EXPORTABLE_SETTING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INVALID_IV"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INVALID_IV"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INVALID_KEY"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_INVALID_KEY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_MISSING_TOKEN"
-msgstr "not yet valid"
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_MISSING_TOKEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_UNSUPPORTED_ALGORITHM"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_UNSUPPORTED_ALGORITHM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_USER_SPECIFIED_KEY_WITHOUT_IV"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_VOLATILEVAULT_USER_SPECIFIED_KEY_WITHOUT_IV"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_GET_CONVERTED_CONVERSION_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_GET_CONVERTED_CONVERSION_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_GET_CONVERTED_MISSING_FORMAT"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_CRYPTO_X509_GET_CONVERTED_MISSING_FORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_GET_CONVERTED_WRONG_FORMAT"
-msgstr "The IP address __IP__ is wrong. We support IPv4 and IPv6 addresses."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_GET_CONVERTED_WRONG_FORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_GET_IDENTIFIER_NOT_INITIALIZED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_GET_IDENTIFIER_NOT_INITIALIZED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_GET_STATUS_NOT_INITIALIZED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_GET_STATUS_NOT_INITIALIZED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_GET_SUBJECT_NOT_INITIALIZED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_GET_SUBJECT_NOT_INITIALIZED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_INIT_OBJECT_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_INIT_OBJECT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_NEW_MISSING_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_NEW_MISSING_DATA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_CRYPTO_X509_NEW_MISSING_TOKEN"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_CRYPTO_X509_NEW_MISSING_TOKEN"
 
 msgid "I18N_OPENXPKI_C_DESC"
 msgstr "Country"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_DATETIME_CONVERT_DATE_INVALID_DATE"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_DATETIME_CONVERT_DATE_INVALID_DATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_DATETIME_CONVERT_DATE_INVALID_FORMAT"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_DATETIME_CONVERT_DATE_INVALID_FORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_DATETIME_GET_VALIDITY_INVALID_VALIDITY"
-msgstr "Change CRR invalidity time"
+msgstr "I18N_OPENXPKI_DATETIME_GET_VALIDITY_INVALID_VALIDITY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_DATETIME_GET_VALIDITY_INVALID_VALIDITY_FORMAT"
-msgstr "The entered date/time could not be validated."
+msgstr "I18N_OPENXPKI_DATETIME_GET_VALIDITY_INVALID_VALIDITY_FORMAT"
 
 msgid "I18N_OPENXPKI_DC_DESC"
 msgstr "Domain Component"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_DEBUG_DEBUG_MESSAGE_IS_NOT_A_CODEREF"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_DEBUG_DEBUG_MESSAGE_IS_NOT_A_CODEREF"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_DELEAYED_REVOCATION_REQUESTED"
-msgstr "Handle a certificate revocation request"
+msgstr "I18N_OPENXPKI_DELEAYED_REVOCATION_REQUESTED"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_DEPLOYMENT_MY_REALM_ID"
-msgstr "Test Dummy CA"
+msgstr "My realm ID"
 
 msgid "I18N_OPENXPKI_DEPLOYMENT_TEST_DUMMY_CA"
 msgstr "Test Dummy CA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_DN_CONVERT_OPENSSL_DN_PARSE_ERROR"
-msgstr "Valid"
+msgstr "I18N_OPENXPKI_DN_CONVERT_OPENSSL_DN_PARSE_ERROR"
 
 msgid "I18N_OPENXPKI_EMAILADDRESS"
 msgstr "E-mail:"
@@ -1437,67 +1332,67 @@ msgstr "failed"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TEMPLATE_DIR_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TEMPLATE_DIR_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TEMPLATE_MISSING_TMP"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TEMPLATE_MISSING_TMP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TMPDIR_MAKE_FAILED"
-msgstr "Logout failed"
+msgstr "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TMPDIR_MAKE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TMPFILE_MAKE_FAILED"
-msgstr "Logout failed"
+msgstr "I18N_OPENXPKI_FILEUTILS_GET_SAFE_TMPFILE_MAKE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_READ_FILE_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_FILEUTILS_READ_FILE_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_READ_FILE_MISSING_PARAMETER"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_FILEUTILS_READ_FILE_MISSING_PARAMETER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_READ_FILE_NOT_READABLE"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_FILEUTILS_READ_FILE_NOT_READABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_READ_FILE_OPEN_FAILED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_FILEUTILS_READ_FILE_OPEN_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_ALREADY_EXISTS"
-msgstr "Expired"
+msgstr "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_ALREADY_EXISTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_NO_CONTENT_SPECIFIED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_NO_CONTENT_SPECIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_NO_FILENAME_SPECIFIED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_NO_FILENAME_SPECIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_OPEN_FAILED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_FILEUTILS_WRITE_FILE_OPEN_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_FOO_BAR"
-msgstr "User profile"
+msgstr "I18N_OPENXPKI_FOO_BAR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_GET_SAFE_TMPFILE_DIR_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_GET_SAFE_TMPFILE_DIR_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_GET_SAFE_TMPFILE_MAKE_FAILED"
-msgstr "Logout failed"
+msgstr "I18N_OPENXPKI_GET_SAFE_TMPFILE_MAKE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_GET_SAFE_TMPFILE_MISSING_TMP"
-msgstr "SPKAC"
+msgstr "I18N_OPENXPKI_GET_SAFE_TMPFILE_MISSING_TMP"
 
 msgid "I18N_OPENXPKI_HOSTNAME"
 msgstr "Hostname"
@@ -1528,31 +1423,27 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_I18N_SETLOCALE_LC_MESSAGES_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_I18N_SETLOCALE_LC_MESSAGES_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_I18N_SETLOCALE_LC_TIME_FAILED"
-msgstr "CSR with DC-style"
+msgstr "I18N_OPENXPKI_I18N_SETLOCALE_LC_TIME_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_MIGRATION_FEATURE_INCOMPLETE"
-msgstr "Incomplete"
+msgstr "I18N_OPENXPKI_MIGRATION_FEATURE_INCOMPLETE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_MODULE_FUNCTION_SPECIFIC_STUFF"
-msgstr "Persist CSR"
+msgstr "I18N_OPENXPKI_MODULE_FUNCTION_SPECIFIC_STUFF"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_MY_CLASS_MY_FUNCTION_MY_MESSAGE"
-msgstr "Change additional information"
+msgstr "I18N_OPENXPKI_MY_CLASS_MY_FUNCTION_MY_MESSAGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_OPENXPKI_SERVER_CONTEXT_WORKFLOW_CLASS_USED_PKI_REALM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_OPENXPKI_SERVER_CONTEXT_WORKFLOW_CLASS_USED_PKI_REALM"
 
 msgid "I18N_OPENXPKI_OU_DESC"
 msgstr "Organizational Unit"
@@ -1584,25 +1475,18 @@ msgstr ""
 msgid "I18N_OPENXPKI_PROFILE_ADVANCED_STYLE"
 msgstr "Advanced naming style"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_OPENVPN_CLIENT"
-msgstr "User profile"
+msgstr "OpenVPN client Profile"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_SCEP_CLIENT_BASIC_DESC"
-msgstr ""
-"If you use this style, you'll only be required to enter your name, username "
-"and e-mail address. This is the easiest way to obtain a certificate, use it "
-"if you have no specific requirement for which you would need the advanced "
-"style."
+msgstr "I18N_OPENXPKI_PROFILE_SCEP_CLIENT_BASIC_DESC"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_SCEP_CLIENT_BASIC_STYLE"
-msgstr "Basic user naming style"
+msgstr "Basic SCEP client naming style"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_SCEP_SIGNER"
-msgstr "User profile"
+msgstr "SCEP signer profile"
 
 msgid "I18N_OPENXPKI_PROFILE_TLS_BASIC_DESC"
 msgstr ""
@@ -1617,21 +1501,20 @@ msgstr "Basic TLS style"
 msgid "I18N_OPENXPKI_PROFILE_TLS_SERVER"
 msgstr "TLS Server profile"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_USER"
 msgstr "User profile"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_USER_AUTHENTICATION"
-msgstr "Basic user naming style"
+msgstr "I18N_OPENXPKI_PROFILE_USER_AUTHENTICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_USER_AUTHENTICATION_MAIL"
-msgstr "Basic user naming style"
+msgstr "I18N_OPENXPKI_PROFILE_USER_AUTHENTICATION_MAIL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_USER_AUTHENTICATION_NOMAIL"
-msgstr "Default key group"
+msgstr "I18N_OPENXPKI_PROFILE_USER_AUTHENTICATION_NOMAIL"
 
 msgid "I18N_OPENXPKI_PROFILE_USER_BASIC_DESC"
 msgstr ""
@@ -1645,31 +1528,31 @@ msgstr "Basic user naming style"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_USER_ENCRYPTION"
-msgstr "User profile"
+msgstr "I18N_OPENXPKI_PROFILE_USER_ENCRYPTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_USER_FSE"
-msgstr "User profile"
+msgstr "I18N_OPENXPKI_PROFILE_USER_FSE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_PROFILE_USER_SIGNATURE"
-msgstr "User profile"
+msgstr "I18N_OPENXPKI_PROFILE_USER_SIGNATURE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_READ_FILE_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_READ_FILE_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_READ_FILE_MISSING_PARAMETER"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_READ_FILE_MISSING_PARAMETER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_READ_FILE_NOT_READABLE"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_READ_FILE_NOT_READABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_READ_FILE_OPEN_FAILED"
-msgstr "Could not open the file"
+msgstr "I18N_OPENXPKI_READ_FILE_OPEN_FAILED"
 
 msgid "I18N_OPENXPKI_REALNAME"
 msgstr "Realname"
@@ -1677,45 +1560,29 @@ msgstr "Realname"
 msgid "I18N_OPENXPKI_REALNAME_DESC"
 msgstr "Your real name, for example 'John Doe'"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_AFFILIATION"
-msgstr "Email address"
+msgstr "Affiliation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_AFFILIATION_DESC"
-msgstr ""
-"If you use this style, you'll only be required to enter your name, username "
-"and e-mail address. This is the easiest way to obtain a certificate, use it "
-"if you have no specific requirement for which you would need the advanced "
-"style."
+msgstr "Requestor affiliation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_EMAIL"
-msgstr "Email address"
+msgstr "Email"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_EMAIL_DESC"
-msgstr ""
-"If you use this style, you'll only be required to enter your name, username "
-"and e-mail address. This is the easiest way to obtain a certificate, use it "
-"if you have no specific requirement for which you would need the advanced "
-"style."
+msgstr "Requestor email"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_FIRSTNAME"
-msgstr "Hostname"
+msgstr "First name"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_FIRSTNAME_DESC"
-msgstr "This is the (fully qualified) hostname"
+msgstr "Requestor first name"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_LASTNAME"
-msgstr "Hostname"
+msgstr "Last name"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_REQUESTOR_LASTNAME_DESC"
-msgstr "This is the (fully qualified) hostname"
+msgstr "Requestor last name"
 
 msgid "I18N_OPENXPKI_SAN_DNS"
 msgstr "DNS"
@@ -1790,169 +1657,143 @@ msgstr "Incomplete"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_FAST_DESERIALIZE_INCORRECT_SERIALIZATION_FORMAT"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_FAST_DESERIALIZE_INCORRECT_SERIALIZATION_FORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_DESERIALIZE_NO_ARG_GIVEN"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_DESERIALIZE_NO_ARG_GIVEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_ARRAY_ELEMENT_POSITION_FORMAT_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_ARRAY_ELEMENT_POSITION_FORMAT_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_ARRAY_LENGTH_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_ARRAY_LENGTH_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_ARRAY_LENGTH_FORMAT_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_ARRAY_LENGTH_FORMAT_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_DATA_TYPE_NOT_SUPPORTED"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_DATA_TYPE_NOT_SUPPORTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_KEY_LENGTH_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_KEY_LENGTH_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_KEY_LENGTH_FORMAT_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_KEY_LENGTH_FORMAT_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_LENGTH_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_LENGTH_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_LENGTH_FORMAT_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_HASH_LENGTH_FORMAT_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_SCALAR_DENOTED_LENGTH_TOO_LONG"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_SCALAR_DENOTED_LENGTH_TOO_LONG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_SCALAR_FORMAT_CORRUPTED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_SCALAR_FORMAT_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_UNDEF_FORMAT_CORRUPTED"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_READ_UNDEF_FORMAT_CORRUPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_SEPARATOR_IS_NUMERIC"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_SEPARATOR_IS_NUMERIC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_SEPARATOR_TOO_LONG"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_SEPARATOR_TOO_LONG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERIALIZATION_SIMPLE_WRITE_DATA_TYPE_NOT_SUPPORTED"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SERIALIZATION_SIMPLE_WRITE_DATA_TYPE_NOT_SUPPORTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_CREATE_PERMISSION_DENIED"
-msgstr "Service error: permission to execute command denied."
+msgstr "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_CREATE_PERMISSION_DENIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_INTERNAL_ERROR"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_INTERNAL_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_READ_PERMISSION_DENIED"
-msgstr "Service error: permission to execute command denied."
+msgstr "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_READ_PERMISSION_DENIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_READ_PERMISSION_DENIED_NO_ACCESS_TO_TYPE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_READ_PERMISSION_DENIED_NO_ACCESS_TO_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_READ_PERMISSION_DENIED_WORKFLOW_CREATOR_NOT_ACCEPTABLE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_READ_PERMISSION_DENIED_WORKFLOW_CREATOR_NOT_ACCEPTABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_UNKNOWN_ACTION"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_ACL_AUTHORIZE_WORKFLOW_UNKNOWN_ACTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACTIVITY_ERROR_PARSING_TEMPLATE_FOR_PARAM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_ACTIVITY_ERROR_PARSING_TEMPLATE_FOR_PARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_ACTIVITY_EVALUATE_ELIGIBILITY_ERROR_PARSING_TEMPLATE"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_ACTIVITY_EVALUATE_ELIGIBILITY_ERROR_PARSING_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_ACL_CHECK_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_ACL_CHECK_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_CREATE_WORKFLOW_INSTANCE_CREATE_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_CREATE_WORKFLOW_INSTANCE_CREATE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_CREATE_WORKFLOW_INSTANCE_ILLEGAL_WORKFLOW_TITLE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_CREATE_WORKFLOW_INSTANCE_ILLEGAL_WORKFLOW_TITLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_CREATE_WORKFLOW_INSTANCE_NO_FIRST_ACTIVITY"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_CREATE_WORKFLOW_INSTANCE_NO_FIRST_ACTIVITY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_DEFAULT_GET_APPROVAL_MESSAGE_NEITHER_SPKAC_NOR_PKCS10_PRESENT_IN_CONTEXT"
-msgstr "Workflow types"
+msgstr "I18N_OPENXPKI_SERVER_API_DEFAULT_GET_APPROVAL_MESSAGE_NEITHER_SPKAC_NOR_PKCS10_PRESENT_IN_CONTEXT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_DEFAULT_GET_CHAIN_MISSING_DEFAULT_TOKEN"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_API_DEFAULT_GET_CHAIN_MISSING_DEFAULT_TOKEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_DEFAULT_METHOD_OBSOLETE"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_API_DEFAULT_METHOD_OBSOLETE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_DEFAULT_NO_SUCH_INPUT_ELEMENT_DEFINED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_API_DEFAULT_NO_SUCH_INPUT_ELEMENT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_EXECUTE_WORKFLOW_ACTIVITY_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_EXECUTE_WORKFLOW_ACTIVITY_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_EXECUTE_WORKFLOW_ACTIVITY_ILLEGAL_PARAM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_EXECUTE_WORKFLOW_ACTIVITY_ILLEGAL_PARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_GET_CHAIN_START_IDENTIFIER_MISSING"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_GET_CHAIN_START_IDENTIFIER_MISSING"
 
 msgid "I18N_OPENXPKI_SERVER_API_INVALID_METHOD_CALLED"
 msgstr ""
@@ -1961,341 +1802,243 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_INVALID_PARAMETER"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_API_INVALID_PARAMETER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_CONTROL_WATCHDOG_INVALID_ACTION"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_CONTROL_WATCHDOG_INVALID_ACTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_CONTROL_WATCHDOG_NO_WATCHDOG"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_CONTROL_WATCHDOG_NO_WATCHDOG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_DSA_UNABLE_TO_GENERATE_DSA_PARAM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_DSA_UNABLE_TO_GENERATE_DSA_PARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_DSA_UNABLE_TO_GENERATE_EC_PARAM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_DSA_UNABLE_TO_GENERATE_EC_PARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_EC_REQUIRES_CURVE_NAME"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_EC_REQUIRES_CURVE_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_REQUIRES_PASSWORD"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GENERATE_KEY_REQUIRES_PASSWORD"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CERT_CERTIFICATE_NOT_FOUND_IN_DB"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CERT_CERTIFICATE_NOT_FOUND_IN_DB"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_MISSING_CA_CONFIG"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_MISSING_CA_CONFIG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_NOT_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_NOT_IN_REALM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_NOT_IN_REALM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_NOT_PUBLIC"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_NOT_PUBLIC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_UNABLE_TO_CONVERT"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CRL_UNABLE_TO_CONVERT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CURRENT_DATA_POOL_ENCRYPTION_KEY_SYMMETRIC_ENCRYPTION_KEY_NOT_AVAILABLE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_CURRENT_DATA_POOL_ENCRYPTION_KEY_SYMMETRIC_ENCRYPTION_KEY_NOT_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_ENTRY_ENCRYPTION_KEY_UNAVAILABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_ENTRY_ENCRYPTION_KEY_UNAVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_ENTRY_PASSWORD_TOKEN_NOT_AVAILABLE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_ENTRY_PASSWORD_TOKEN_NOT_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_INVALID_PKI_REALM"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_INVALID_PKI_REALM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_SYMMETRIC_ENCRYPTION_KEY_NOT_AVAILABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_DATA_POOL_SYMMETRIC_ENCRYPTION_KEY_NOT_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_GET_PRIVATE_KEY_FOR_CERT_COULD_NOT_DETERMINE_KEY_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_GET_PRIVATE_KEY_FOR_CERT_COULD_NOT_DETERMINE_KEY_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_LIST_DATA_POOL_ENTRIES_INVALID_PKI_REALM"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_LIST_DATA_POOL_ENTRIES_INVALID_PKI_REALM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_PRIVATE_KEY_NOT_FOUND_IN_DB"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_PRIVATE_KEY_NOT_FOUND_IN_DB"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SEARCH_CERT_INVALID_CERT_ATTRIBUTES_ARGUMENTS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SEARCH_CERT_INVALID_CERT_ATTRIBUTES_ARGUMENTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SEARCH_CERT_SELECT_RESULT_NOT_ARRAY"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SEARCH_CERT_SELECT_RESULT_NOT_ARRAY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_CERT_NOT_AVAILABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_CERT_NOT_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_ENTRY_ENTRY_EXISTS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_ENTRY_ENTRY_EXISTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_ILLEGAL_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_ILLEGAL_DATA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_ENCRYPTION_MODE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_ENCRYPTION_MODE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_EXPIRATION_DATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_EXPIRATION_DATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_NAMESPACE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_NAMESPACE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_PKI_REALM"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_PKI_REALM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_VALUE_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_SET_DATA_POOL_INVALID_VALUE_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_OBJECT_VALIDATE_CERTIFICATE_NO_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_OBJECT_VALIDATE_CERTIFICATE_NO_DATA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_METADATA_FROM_TEMPLATE_ERROR_PARSING_TEMPLATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_METADATA_FROM_TEMPLATE_ERROR_PARSING_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SAN_FROM_TEMPLATE_ERROR_PARSING_TEMPLATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SAN_FROM_TEMPLATE_ERROR_PARSING_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SAN_FROM_TEMPLATE_UNKNOWN_SAN_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SAN_FROM_TEMPLATE_UNKNOWN_SAN_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SUBJECT_FROM_TEMPLATE_ERROR_PARSING_TEMPLATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SUBJECT_FROM_TEMPLATE_ERROR_PARSING_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SUBJECT_FROM_TEMPLATE_NO_DN_TEMPLATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_PROFILE_RENDER_SUBJECT_FROM_TEMPLATE_NO_DN_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_CERT_INVALID_CERTFORMAT"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_CERT_INVALID_CERTFORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_CERT_INVALID_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_CERT_INVALID_DATA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_CERT_PARSING_REQUIRED_FOR_CERTFORMAT"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_CERT_PARSING_REQUIRED_FOR_CERTFORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_INVALID_SMARTCARD_STATUS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_INVALID_SMARTCARD_STATUS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_INVALID_WORKFLOW_TYPES_UNEXPECTED_DATA_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_INVALID_WORKFLOW_TYPES_UNEXPECTED_DATA_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_NO_EMPLOYEEID_FOR_TOKEN"
-msgstr "Certificates"
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_NO_EMPLOYEEID_FOR_TOKEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_PERSON_ENTRY_DOES_NOT_HAVE_MAIL_ATTRIBUTE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_PERSON_ENTRY_DOES_NOT_HAVE_MAIL_ATTRIBUTE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_SEARCH_PERSON_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_SEARCH_PERSON_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_TOKEN_NOT_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_TOKEN_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_TOO_MANY_SMARTCARDS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_TOO_MANY_SMARTCARDS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_UNSUPPORTED_SMARTCARD_TYPE"
-msgstr "Certificates"
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_ANALYZE_SMARTCARD_UNSUPPORTED_SMARTCARD_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_PARSE_CERTIFICATES_INVALID_CERT_FORMAT"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SMARTCARD_SC_PARSE_CERTIFICATES_INVALID_CERT_FORMAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_SUBCLASSES_CAN_NOT_BE_INSTANTIATED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_SUBCLASSES_CAN_NOT_BE_INSTANTIATED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_VISUALIZATION_GET_WORKFLOW_INFO_DOT_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_VISUALIZATION_GET_WORKFLOW_INFO_DOT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_CHILD_FACTORY_NOT_DEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_CHILD_FACTORY_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_CHILD_WORKFLOW_COULD_NOT_BE_FETCHED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_CHILD_WORKFLOW_COULD_NOT_BE_FETCHED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_COULD_NOT_DETERMINE_CHILD_TYPE_AND_ID"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_COULD_NOT_DETERMINE_CHILD_TYPE_AND_ID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_DESERIALIZING_WF_CHILDREN_CONTEXT_PARAMETER_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_DESERIALIZING_WF_CHILDREN_CONTEXT_PARAMETER_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_FACTORY_NOT_DEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_FACTORY_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_NO_CHILDREN_INSTANCES_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_NO_CHILDREN_INSTANCES_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_WORKFLOW_COULD_NOT_BE_FETCHED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_CERT_IDENTIFIER_BY_CSR_WF_WORKFLOW_COULD_NOT_BE_FETCHED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_WORKFLOW_FACTORY_FACTORY_NOT_DEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_WORKFLOW_FACTORY_FACTORY_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_WORKFLOW_TYPE_FOR_ID_NO_RESULT_FOR_ID"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_GET_WORKFLOW_TYPE_FOR_ID_NO_RESULT_FOR_ID"
 
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_MISSING_REQUIRED_FIELDS"
 msgstr ""
@@ -2304,72 +2047,65 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_SEARCH_WORKFLOW_INSTANCES_STATE_NOT_ALPHANUMERIC"
-msgstr "At least one context entry is needed."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_SEARCH_WORKFLOW_INSTANCES_STATE_NOT_ALPHANUMERIC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_API_WORKFLOW_SEARCH_WORKFLOW_INSTANCES_TYPE_NOT_ALPHANUMERIC"
-msgstr "At least one context entry is needed."
+msgstr "I18N_OPENXPKI_SERVER_API_WORKFLOW_SEARCH_WORKFLOW_INSTANCES_TYPE_NOT_ALPHANUMERIC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_CLIENT_SSO_LOGIN_FAILED"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_CLIENT_SSO_LOGIN_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_EXTERNAL_LOGIN_FAILED"
-msgstr ""
-"You could not be authenticated using your certificate with CN __USER__."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_EXTERNAL_LOGIN_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_EXTERNAL_UNKNOWN_ROLE"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_EXTERNAL_UNKNOWN_ROLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_INCORRECT_HANDLER"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_INCORRECT_HANDLER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_LOAD_HANDLER_CRASHED"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_LOAD_HANDLER_CRASHED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_LOAD_HANDLER_FAILED"
-msgstr ""
-"You could not be authenticated using your certificate with CN __USER__."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_LOAD_HANDLER_FAILED"
 
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_LOGIN_FAILED"
 msgstr "Login failed"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_LOGIN_INVALID_STACK"
-msgstr ""
-"You could not be authenticated using your certificate with CN __USER__."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_LOGIN_INVALID_STACK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_PASSWORD_CONNECTOR_RETURN_NOT_SCALAR"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_PASSWORD_CONNECTOR_RETURN_NOT_SCALAR"
 
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_PASSWORD_LOGIN_FAILED"
 msgstr "The login of the user __USER__ failed. Please try again."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_PASSWORD_NEW_MISSING_SCHEME_SPECIFICATION"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_PASSWORD_NEW_MISSING_SCHEME_SPECIFICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_PASSWORD_UNSUPPORTED_SCHEME"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_PASSWORD_UNSUPPORTED_SCHEME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_ABSTRACT_CLASS"
-msgstr "Test User CA"
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_ABSTRACT_CLASS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_CERT_UNKNOWN_ROLE_HANDLER_ARGUMENT"
-msgstr "The certificate was not found in the database or is invalid."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_CERT_UNKNOWN_ROLE_HANDLER_ARGUMENT"
 
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_CHALLENGE_DOES_NOT_MATCH_SESSION_ID"
 msgstr "Challenge does not match session ID."
@@ -2379,8 +2115,7 @@ msgstr "Invalid signature."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_LOGIN_FAILED"
-msgstr ""
-"You could not be authenticated using your certificate with CN __USER__."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_LOGIN_FAILED"
 
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_MISSING_TRUST_ANCHOR_CONFIGURATION"
 msgstr "Configuration error: missing trust anchor"
@@ -2390,934 +2125,783 @@ msgstr "Signature is not in Base64 format."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_SIGNER_CERT_NOT_TRUSTED"
-msgstr "Signature is not in Base64 format."
+msgstr "I18N_OPENXPKI_SERVER_AUTHENTICATION_X509_SIGNER_CERT_NOT_TRUSTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_COMMAND_MISSING_SESSION"
-msgstr "Service error: permission to execute command denied."
+msgstr "I18N_OPENXPKI_SERVER_COMMAND_MISSING_SESSION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_DAEMON_GROUP"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_DAEMON_GROUP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_SOCKET_OWNER"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_SOCKET_OWNER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_SOCKET_OWNER_GROUP"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_SOCKET_OWNER_GROUP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_USER"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_CONFIG_INCORRECT_USER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONFIG_MISSING_PARAMETER"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SERVER_CONFIG_MISSING_PARAMETER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONFIG_SOCKETFILE_TOO_LONG"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_CONFIG_SOCKETFILE_TOO_LONG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONNECTOR_NICE_CONDITION_CERTIFICATEISSUED_NOENTRY"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_CONNECTOR_NICE_CONDITION_CERTIFICATEISSUED_NOENTRY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONNECTOR_NICE_CONDITION_CERTIFICATEISSUED_STILLPENDING"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_CONNECTOR_NICE_CONDITION_CERTIFICATEISSUED_STILLPENDING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONNECTOR_VICE_CONDITION_CERTIFICATE_NOT_PENDING"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_CONNECTOR_VICE_CONDITION_CERTIFICATE_NOT_PENDING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONTEXT_CTX_NOT_INITIALIZED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERVER_CONTEXT_CTX_NOT_INITIALIZED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONTEXT_CTX_OBJECT_NOT_DEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_CONTEXT_CTX_OBJECT_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONTEXT_CTX_OBJECT_NOT_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_CONTEXT_CTX_OBJECT_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONTEXT_SETCONTEXT_ALREADY_DEFINED"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_CONTEXT_SETCONTEXT_ALREADY_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONTEXT_SETCONTEXT_ILLEGAL_ENTRY"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_CONTEXT_SETCONTEXT_ILLEGAL_ENTRY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_CONTEXT_SETCONTEXT_UNDEFINED_VALUE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_CONTEXT_SETCONTEXT_UNDEFINED_VALUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_COULD_NOT_RECONNECT_DBI_LOG"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_COULD_NOT_RECONNECT_DBI_LOG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_AUTOCOMMIT"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_AUTOCOMMIT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_COMMIT_FAILED"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_COMMIT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_CONNECT_EXCEPTION"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_CONNECT_EXCEPTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_CONNECT_FAILED"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_CONNECT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_DISCONNECT_FAILED"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_DISCONNECT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_LIMIT_AMOUNT_IS_NOT_A_NUMBER"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_LIMIT_AMOUNT_IS_NOT_A_NUMBER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_LIMIT_IS_NOT_A_NUMBER"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_LIMIT_IS_NOT_A_NUMBER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_LIMIT_START_IS_NOT_A_NUMBER"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_LIMIT_START_IS_NOT_A_NUMBER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_NOT_CONNECTED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_DO_QUERY_NOT_CONNECTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_EXECUTE_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_EXECUTE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_MISSING_DATABASE_TYPE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_MISSING_DATABASE_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_PREPARE_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_PREPARE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DBH_ROLLBACK_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DBH_ROLLBACK_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_DROP_SEQUENCE_NOT_FORCED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_DROP_SEQUENCE_NOT_FORCED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_GET_DSN_NO_DATABASE_NAME"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_GET_DSN_NO_DATABASE_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_GET_NEW_SERIAL_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_GET_NEW_SERIAL_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_GET_NEW_SERIAL_NO_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_DB2_GET_NEW_SERIAL_NO_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_GET_ABSTRACT_COLUMN_TYPE_UNKNOWN_NAME"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_GET_ABSTRACT_COLUMN_TYPE_UNKNOWN_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_GET_COLUMN_TYPE_UNKNOWN_NAME"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_GET_COLUMN_TYPE_UNKNOWN_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_DROP_SEQUENCE_NOT_FORCED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_DROP_SEQUENCE_NOT_FORCED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_GET_DSN_NO_DATABASE_NAME"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_GET_DSN_NO_DATABASE_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_GET_NEW_SERIAL_NO_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_GET_NEW_SERIAL_NO_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_LAST_INSERT_ID_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_MYSQL_LAST_INSERT_ID_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_NEW_DRIVER_LOAD_ERROR"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_NEW_DRIVER_LOAD_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_NEW_WRONG_TYPE_IN_SCHEMA"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_NEW_WRONG_TYPE_IN_SCHEMA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_ORACLE_DROP_SEQUENCE_NOT_FORCED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_ORACLE_DROP_SEQUENCE_NOT_FORCED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_ORACLE_GET_NEW_SERIAL_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_ORACLE_GET_NEW_SERIAL_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_POSTGRESQL_DROP_SEQUENCE_NOT_FORCED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_POSTGRESQL_DROP_SEQUENCE_NOT_FORCED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_POSTGRESQL_GET_NEW_SERIAL_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_POSTGRESQL_GET_NEW_SERIAL_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_DROP_SEQUENCE_NOT_FORCED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_DROP_SEQUENCE_NOT_FORCED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_GET_DSN_NO_DATABASE_NAME"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_GET_DSN_NO_DATABASE_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_GET_NEW_SERIAL_NO_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_GET_NEW_SERIAL_NO_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_GET_NEXT_ID_FUNC_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_DRIVER_SQLITE_GET_NEXT_ID_FUNC_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_HASH_LOG_WRITE_ACTION_WRONG_INDEX_COLUMN"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_HASH_LOG_WRITE_ACTION_WRONG_INDEX_COLUMN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_MISSING_LOG"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_DBI_MISSING_LOG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_CHECK_PARAMETER_"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_CHECK_PARAMETER_"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_COLUMN_UNKNOWN_COLUMN"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_COLUMN_UNKNOWN_COLUMN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_INDEX_COLUMNS_UNKNOWN_INDEX"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_INDEX_COLUMNS_UNKNOWN_INDEX"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_INDEX_NAME_UNKNOWN_INDEX"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_INDEX_NAME_UNKNOWN_INDEX"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_INDEX_TABLE_UNKNOWN_INDEX"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_INDEX_TABLE_UNKNOWN_INDEX"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_SEQUENCE_NAME_UNKNOWN_SEQUENCE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_SEQUENCE_NAME_UNKNOWN_SEQUENCE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_TABLE_COLUMNS_UNKNOWN_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_TABLE_COLUMNS_UNKNOWN_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_TABLE_INDEX_UNKNOWN_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_TABLE_INDEX_UNKNOWN_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_TABLE_NAME_UNKNOWN_TABLE"
-msgstr ""
-"The type __TYPE__ is not supported for a subject alternative name field."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SCHEMA_GET_TABLE_NAME_UNKNOWN_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_DELETE_WRONG_COLUMN"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_DELETE_WRONG_COLUMN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_DELETE_WRONG_OPERATOR"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_DELETE_WRONG_OPERATOR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_DROP_INDEX_NOT_FORCED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_DROP_INDEX_NOT_FORCED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_DROP_TABLE_NOT_FORCED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_DROP_TABLE_NOT_FORCED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_GET_SYMBOLIC_QUERY_COLUMNS_MISSING_COLUMNS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_GET_SYMBOLIC_QUERY_COLUMNS_MISSING_COLUMNS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_GET_VALIDITY_CONDITION_INCORRECT_VALIDITY_ARGUMENTS"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_GET_VALIDITY_CONDITION_INCORRECT_VALIDITY_ARGUMENTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_NORMALIZE_VALIDITY_INVALID_ARGUMENT"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_NORMALIZE_VALIDITY_INVALID_ARGUMENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_ORDER_INVALID_ENTRY"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_ORDER_INVALID_ENTRY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_ORDER_IS_NOT_ARRAYREF"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_ORDER_IS_NOT_ARRAYREF"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_ALIAS_NOT_UNIQUE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_ALIAS_NOT_UNIQUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_COLUMN_NOT_SPECIFIED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_COLUMN_NOT_SPECIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_DYNAMIC_NO_HASH_REFERENCE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_DYNAMIC_NO_HASH_REFERENCE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_DYNAMIC_PARAM_NO_HASH_REFERENCE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_DYNAMIC_PARAM_NO_HASH_REFERENCE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_DYNAMIC_PARAM_WITHOUT_VALUE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_DYNAMIC_PARAM_WITHOUT_VALUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_FETCHROW_RETURNED_ERROR"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_FETCHROW_RETURNED_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_COLUMN_DATA_TYPE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_COLUMN_DATA_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_NUMBER_OF_SYMBOLIC_TABLE_ENTRIES"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_NUMBER_OF_SYMBOLIC_TABLE_ENTRIES"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_TABLE_SPECIFICATION"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_TABLE_SPECIFICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_VALIDITY_SPECIFICATION_TYPE_FOR_JOIN"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INCORRECT_VALIDITY_SPECIFICATION_TYPE_FOR_JOIN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INVALID_AGGREGATE_SPECIFICATION"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INVALID_AGGREGATE_SPECIFICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INVALID_DYNAMIC_QUERY"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INVALID_DYNAMIC_QUERY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INVALID_TABLE_FOR_VALIDITY_CONSTRAINT"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_INVALID_TABLE_FOR_VALIDITY_CONSTRAINT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_JOIN_SPECIFICATION_MISMATCH"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_JOIN_SPECIFICATION_MISMATCH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_LIKE_ON_NUMERIC"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_LIKE_ON_NUMERIC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_MISSING_COLUMNS"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_MISSING_COLUMNS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_MISSING_JOIN"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_MISSING_JOIN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_MISSING_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_MISSING_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_NO_COLUMNS_SELECTED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_NO_COLUMNS_SELECTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_NO_WHERE_CLAUSE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_NO_WHERE_CLAUSE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_UNKNOWN_OPERATOR"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_UNKNOWN_OPERATOR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_VALIDITY_SPECIFICATION_MISMATCH_FOR_JOIN"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_VALIDITY_SPECIFICATION_MISMATCH_FOR_JOIN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_WRONG_COLUMN"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_SELECT_WRONG_COLUMN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_DBI_SQL_UPDATE_NO_DATA_PRESENT"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_DBI_SQL_UPDATE_NO_DATA_PRESENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_GET_USER_INTERFACE_SERVICE_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_GET_USER_INTERFACE_SERVICE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_GET_USER_INTERFACE_TRANSPORT_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_GET_USER_INTERFACE_TRANSPORT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_DO_INIT_AUTHENTICATION_INSTANTIATION_FAILURE"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_INIT_DO_INIT_AUTHENTICATION_INSTANTIATION_FAILURE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_DO_INIT_VOLATILEVAULT_MISSING_TOKEN"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_INIT_DO_INIT_VOLATILEVAULT_MISSING_TOKEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_LOCALE_DIRECTORY_MISSING"
-msgstr "Pending (in editing state)"
+msgstr "I18N_OPENXPKI_SERVER_INIT_LOCALE_DIRECTORY_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_TASK_CONFIG_LAYER_NOT_INITIALISED"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERVER_INIT_TASK_CONFIG_LAYER_NOT_INITIALISED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_TASK_GIT_DBPATH_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SERVER_INIT_TASK_GIT_DBPATH_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_TASK_ILLEGAL_TASK_ACTION"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_INIT_TASK_ILLEGAL_TASK_ACTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_TASK_INIT_FAILURE"
-msgstr "Serverside key generation"
+msgstr "I18N_OPENXPKI_SERVER_INIT_TASK_INIT_FAILURE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_WATCHDOG_FORK_FAILED_MAX_REDO"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_INIT_WATCHDOG_FORK_FAILED_MAX_REDO"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_INIT_WATCHDOG_FORK_FAILED_UNRECOVERABLE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_INIT_WATCHDOG_FORK_FAILED_UNRECOVERABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_LOG_EMPTY_LOG_MESSAGE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_LOG_EMPTY_LOG_MESSAGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_LOG_NEW_LOG4PERL_INIT_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_LOG_NEW_LOG4PERL_INIT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_LOG_NEW_MISSING_LOGGER"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_LOG_NEW_MISSING_LOGGER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_LOG_NEW_NO_CONFIGFILE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_LOG_NEW_NO_CONFIGFILE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_CERTSIGN_TOKEN_NOT_USABLE"
-msgstr "Service error: invalid session."
+msgstr "I18N_OPENXPKI_SERVER_NICE_CERTSIGN_TOKEN_NOT_USABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_CRLISSUANCE_NO_CA_ID"
-msgstr "Next CA determined"
+msgstr "I18N_OPENXPKI_SERVER_NICE_CRLISSUANCE_NO_CA_ID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_CRL_TOKEN_NOT_USABLE"
-msgstr "Service error: invalid session."
+msgstr "I18N_OPENXPKI_SERVER_NICE_CRL_TOKEN_NOT_USABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_CRR_NOT_FOUND_IN_DATABASE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_NICE_CRR_NOT_FOUND_IN_DATABASE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_CSR_NOT_FOUND_IN_DATABASE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_NICE_CSR_NOT_FOUND_IN_DATABASE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_CSR_WRONG_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_NICE_CSR_WRONG_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_DEFAULT_TOKEN_NOT_AVAILABLE"
-msgstr "Service error: invalid session."
+msgstr "I18N_OPENXPKI_SERVER_NICE_DEFAULT_TOKEN_NOT_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_LOCAL_CA_TOKEN_UNAVAILABLE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_NICE_LOCAL_CA_TOKEN_UNAVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_LOCAL_CRL_NO_DELTA_CRL_SUPPORT"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_NICE_LOCAL_CRL_NO_DELTA_CRL_SUPPORT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_LOCAL_ISSUE_NOT_AFTER_NOT_SET"
-msgstr "Next CA determined"
+msgstr "I18N_OPENXPKI_SERVER_NICE_LOCAL_ISSUE_NOT_AFTER_NOT_SET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_LOCAL_REVOCATION_PENDING"
-msgstr "Pending (in editing state)"
+msgstr "I18N_OPENXPKI_SERVER_NICE_LOCAL_REVOCATION_PENDING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_NOT_IMPLEMENTED_ERROR"
-msgstr "New Request (CSR)"
+msgstr "I18N_OPENXPKI_SERVER_NICE_NOT_IMPLEMENTED_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NICE_NO_SUCH_BACKEND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_NICE_NO_SUCH_BACKEND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_BASE_NOTIFY_UNIMPLEMENTED"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_BASE_NOTIFY_UNIMPLEMENTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_COULD_NOT_INSTANTIATE_CLIENT"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_COULD_NOT_INSTANTIATE_CLIENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_MISSING_TEMPLATE"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_MISSING_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_NO_ACTIO"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_NO_ACTIO"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_NO_ACTION"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_NO_ACTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_NO_OPEN_TICKET"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_NO_OPEN_TICKET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_OPEN_ON_EXISTING_TICKET"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_RT_OPEN_ON_EXISTING_TICKET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_COULD_NOT_INSTANTIATE_CLIENT"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_COULD_NOT_INSTANTIATE_CLIENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_NO_OPEN_TICKET"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_NO_OPEN_TICKET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_OPEN_ON_EXISTING_TICKET"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_OPEN_ON_EXISTING_TICKET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_SOAP_CALL_FAILED"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_SOAP_CALL_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_SOAP_ERROR"
-msgstr "The login of the user __USER__ failed. Please try again."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_SOAP_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_UNKNOWN_ACTION"
-msgstr ""
-"You called an invalid method at the OpenXPKI server. The illegal method name "
-"is __METHOD_NAME__."
+msgstr "I18N_OPENXPKI_SERVER_NOTIFICATION_SERVICENOW_UNKNOWN_ACTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_POST_BIND_HOOK_COULD_NOT_CHANGE_SOCKET_OWNERSHIP"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_POST_BIND_HOOK_COULD_NOT_CHANGE_SOCKET_OWNERSHIP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_POST_BIND_HOOK_INCORRECT_SOCKET_GROUP"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_POST_BIND_HOOK_INCORRECT_SOCKET_GROUP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_POST_BIND_HOOK_INCORRECT_SOCKET_OWNER"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_POST_BIND_HOOK_INCORRECT_SOCKET_OWNER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_REDIRECT_STDERR_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_REDIRECT_STDERR_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_REDIRECT_STDERR_MISSING_STDERR"
-msgstr "Pending (in editing state)"
+msgstr "I18N_OPENXPKI_SERVER_REDIRECT_STDERR_MISSING_STDERR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_SESSION_IMPORT_SERIALIZED_STRING_CAN_NOT_BE_EMPTY"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_SESSION_IMPORT_SERIALIZED_STRING_CAN_NOT_BE_EMPTY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_SESSION_IMPORT_SERIALIZED_STRING_MUST_BE_HASH"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_SESSION_IMPORT_SERIALIZED_STRING_MUST_BE_HASH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_SESSION_NEW_CREATE_SESSION_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_SESSION_NEW_CREATE_SESSION_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_SESSION_NEW_DIRECTORY_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SERVER_SESSION_NEW_DIRECTORY_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_SESSION_NEW_LOAD_SESSION_FAILED"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER_SESSION_NEW_LOAD_SESSION_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_SESSION_NEW_MISSING_DIRECTORY"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_SESSION_NEW_MISSING_DIRECTORY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_SESSION_NEW_MISSING_LIFETIME"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_SERVER_SESSION_NEW_MISSING_LIFETIME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_EXECUTION_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_EXECUTION_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_HISTORY_AVAILABLE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_HISTORY_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_ID_GIVEN"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_ID_GIVEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_LAST_ACTIVITY"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_LAST_ACTIVITY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_PKI_REALM_GIVEN"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_PKI_REALM_GIVEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_SESSION_INFO_GIVEN"
-msgstr "Service error: permission to execute command denied."
+msgstr "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_SESSION_INFO_GIVEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_WFTYPE_GIVEN"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WATCHDOG_FORK_WORKFLOW_NO_WFTYPE_GIVEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WF_ACTIVITY_CRR_PERSISTREQUEST_SOURCES_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WF_ACTIVITY_CRR_PERSISTREQUEST_SOURCES_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WF_ACTIVITY_CSR_PERSISTREQUEST_SOURCES_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WF_ACTIVITY_CSR_PERSISTREQUEST_SOURCES_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WF_ACTIVITY_CSR_PERSISTREQUEST_SUBJECT_ALT_NAME_SOURCE_UNDEFINED"
-msgstr ""
-"The GUID __GUID__ is not a valid Microsoft GUID and not a valid RFC 4122 "
-"UUID."
+msgstr "I18N_OPENXPKI_SERVER_WF_ACTIVITY_CSR_PERSISTREQUEST_SUBJECT_ALT_NAME_SOURCE_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_NSARRAY_MISSING_FUNCTION"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_NSARRAY_MISSING_FUNCTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_NSARRAY_MISSING_INDEX"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_NSARRAY_MISSING_INDEX"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_NSARRAY_MISSING_PARAM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_NSARRAY_MISSING_PARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_WFHASH_MISSING_PARAM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WF_ACTIVITY_TOOLS_WFHASH_MISSING_PARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CRLISSUANCE_CREATEQUEUE_RENEWAL_NOT_GIVEN_OR_NOT_RELATIVE"
-msgstr "Certificates"
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CRLISSUANCE_CREATEQUEUE_RENEWAL_NOT_GIVEN_OR_NOT_RELATIVE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_MISSING_OR_EMPTY_PASSWORD"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_MISSING_OR_EMPTY_PASSWORD"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_MISSING_PARAMETERS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_MISSING_PARAMETERS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_UNSUPPORTED_PARAMNAME"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_UNSUPPORTED_PARAMNAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_UNSUPPORTED_PARAMVALUE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_UNSUPPORTED_PARAMVALUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_WRONG_KEYTYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_GENERATEKEY_WRONG_KEYTYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_PROFILE_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_PROFILE_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_ROLE_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_ROLE_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_SUBJECT_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_SUBJECT_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_TYPE_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_CSR_PERSISTREQUEST_CSR_TYPE_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_REPORTS_CERTEXPORT_GETCONFIG_NO_SUBJECT"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_REPORTS_CERTEXPORT_GETCONFIG_NO_SUBJECT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_REPORTS_CERTEXPORT_GETCONFIG_WRONG_UMASK"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_REPORTS_CERTEXPORT_GETCONFIG_WRONG_UMASK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_RETRIES_EXEEDED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_RETRIES_EXEEDED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SCEP_EVALUATE_CHALLENGE_ERROR_PARSING_TEMPLATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SCEP_EVALUATE_CHALLENGE_ERROR_PARSING_TEMPLATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SCEP_EVALUATE_CHALLENGE_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SCEP_EVALUATE_CHALLENGE_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_APPLYCSRPOLICY_LOGINID_NOT_ALLOWED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_APPLYCSRPOLICY_LOGINID_NOT_ALLOWED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_APPLYCSRPOLICY_NO_UPN_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_APPLYCSRPOLICY_NO_UPN_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_APPLYCSRPOLICY_TOO_MANY_LOGINIDS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_APPLYCSRPOLICY_TOO_MANY_LOGINIDS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_COMPUTEPUK_NO_DEFAULT_PUK_AVAILABLE"
-msgstr "Cannot get a token to publish DER-certificate"
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_COMPUTEPUK_NO_DEFAULT_PUK_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_COMPUTEPUK_TOKEN_NOT_SUPPORTED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_COMPUTEPUK_TOKEN_NOT_SUPPORTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_CREATEESCROWEDKEY_WRONG_KEYTYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_CREATEESCROWEDKEY_WRONG_KEYTYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GENACTCODE_USER_NOT_AUTH_PERS"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GENACTCODE_USER_NOT_AUTH_PERS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GENERATEPUK_BAD_POLICY"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GENERATEPUK_BAD_POLICY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETLDAPDATA_LDAP_BIND_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETLDAPDATA_LDAP_BIND_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETLDAPDATA_LDAP_CONNECTION_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETLDAPDATA_LDAP_CONNECTION_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETLDAPDATA_LDAP_ENTRY_NOT_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETLDAPDATA_LDAP_ENTRY_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETOWNERBYCARDID"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETOWNERBYCARDID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETOWNERBYCARDID_PERSON_ENTRY_DOES_NOT_HAVE_MAIL_ATTRIBUTE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETOWNERBYCARDID_PERSON_ENTRY_DOES_NOT_HAVE_MAIL_ATTRIBUTE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETOWNERBYCARDID_SEARCH_PERSON_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_GETOWNERBYCARDID_SEARCH_PERSON_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_PERSISTCSRS_CERT_ISSUANCE_DATA_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_PERSISTCSRS_CERT_ISSUANCE_DATA_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_PUBLISHCERTIFICATES_COULD_NOT_CONVERT_CERT_TO_DER"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_PUBLISHCERTIFICATES_COULD_NOT_CONVERT_CERT_TO_DER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_PUBLISHCERTIFICATE_UNABLE_TO_LOAD_CERTIFICATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_SMARTCARD_PUBLISHCERTIFICATE_UNABLE_TO_LOAD_CERTIFICATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TEST_CRASHED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TEST_CRASHED"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_APPROVE_CONTEXT_HASH_CHECK_FAILED"
 msgstr ""
@@ -3327,449 +2911,363 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_APPROVE_COULD_NOT_DETERMINE_SIGNER_CERTIFICATE_IDENTIFIER"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_APPROVE_COULD_NOT_DETERMINE_SIGNER_CERTIFICATE_IDENTIFIER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_APPROVE_NOT_ALLOWED_TO_APPROVE_YOURSELF"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_APPROVE_NOT_ALLOWED_TO_APPROVE_YOURSELF"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CALCULATEKEYID_UNABLE_TO_LOAD_CERTIFICATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CALCULATEKEYID_UNABLE_TO_LOAD_CERTIFICATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CALCULATEKEYID_UNABLE_TO_PARSE_CERTIFICATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CALCULATEKEYID_UNABLE_TO_PARSE_CERTIFICATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CONNECTOR_GET_VALUE_NO_PATH"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CONNECTOR_GET_VALUE_NO_PATH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CONNECTOR_MISSPARAM_VALUE_PARAM_OR_MAP"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_CONNECTOR_MISSPARAM_VALUE_PARAM_OR_MAP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_ENCRYPT_PARAM_NONVOL"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_ENCRYPT_PARAM_NONVOL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_EXISTING_VALUE_NOT_AN_ARRAY"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_EXISTING_VALUE_NOT_AN_ARRAY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_MISSPARAM_KEY"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_MISSPARAM_KEY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_MISSPARAM_NAMESPACE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_MISSPARAM_NAMESPACE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_MODIFYENTRY_MISSPARAM"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_DATAPOOL_MODIFYENTRY_MISSPARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_MISSING_DESTINATION"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_MISSING_DESTINATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_MISSING_STATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_MISSING_STATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_MKDIR_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_MKDIR_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_OPEN_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_EXPORT_OPEN_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_GENERATEPASSWORD_INVALID_LENGTH"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_GENERATEPASSWORD_INVALID_LENGTH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_LOADCERTIFICATEMETADATA_CERT_IDENTIFIER_NOT_DEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_LOADCERTIFICATEMETADATA_CERT_IDENTIFIER_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_NOTIFY_MESSAGE_UNDEFINED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_NOTIFY_MESSAGE_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PARSE_CERT_INVALID_ATTRIBUTE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PARSE_CERT_INVALID_ATTRIBUTE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PARSE_CERT_INVALID_ATTRIBUTE_DATA_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PARSE_CERT_INVALID_ATTRIBUTE_DATA_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PERSIST_CERTIFICATE_METADATA_NO_PROFILE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PERSIST_CERTIFICATE_METADATA_NO_PROFILE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CERTIFICATES_COULD_NOT_CONVERT_CERT_TO_DER"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CERTIFICATES_COULD_NOT_CONVERT_CERT_TO_DER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CERTIFICATE_UNABLE_TO_LOAD_CERTIFICATE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CERTIFICATE_UNABLE_TO_LOAD_CERTIFICATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CRL_COULD_NOT_CONVERT_CRL_TO_DER"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CRL_COULD_NOT_CONVERT_CRL_TO_DER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CRL_UNABLE_TO_LOAD_CRL"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_PUBLISH_CRL_UNABLE_TO_LOAD_CRL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RENDER_SUBJECT_DN_RESULT_EMPTY"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RENDER_SUBJECT_DN_RESULT_EMPTY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RENDER_SUBJECT_NO_PROFILE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RENDER_SUBJECT_NO_PROFILE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RETRIEVECERTIFICATE_INVALID_CERTSTATUS_SPECIFICATION"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RETRIEVECERTIFICATE_INVALID_CERTSTATUS_SPECIFICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RETRIEVECERTIFICATE_INVALID_TIME_SPECIFICATION"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RETRIEVECERTIFICATE_INVALID_TIME_SPECIFICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RETRIEVECERTIFICATE_QUERY_ERROR"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_RETRIEVECERTIFICATE_QUERY_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_REVOKE_CERTIFICATE_NO_CERT_IDENTIFIER"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_REVOKE_CERTIFICATE_NO_CERT_IDENTIFIER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_SETCONTEXT_INVALID_EXTENDED_SYNTAX"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_SETCONTEXT_INVALID_EXTENDED_SYNTAX"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_SETCONTEXT_INVALID_EXTENDED_SYNTAX_CODEREF"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ACTIVITY_TOOLS_SETCONTEXT_INVALID_EXTENDED_SYNTAX_CODEREF"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_API_GET_WORKFLOW_FACTORY_REALM_MISSMATCH"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_API_GET_WORKFLOW_FACTORY_REALM_MISSMATCH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_API_GET_WORKFLOW_FACTORY_UNABLE_TO_LOAD_WORKFLOW_INFO"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_API_GET_WORKFLOW_FACTORY_UNABLE_TO_LOAD_WORKFLOW_INFO"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_API_GET_WORKFLOW_FACTORY_UNABLE_TO_PARSE_WORKFLOW_INFO"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_API_GET_WORKFLOW_FACTORY_UNABLE_TO_PARSE_WORKFLOW_INFO"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_ALWAYS_FALSE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_ALWAYS_FALSE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_APPROVED_MISSING_APPROVAL"
-msgstr "The value of a subject alternative name field is missing."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_APPROVED_MISSING_APPROVAL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_APPROVED_NO_ROLE_LIST"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_APPROVED_NO_ROLE_LIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_AUTHS_NOT_UNIQUE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_AUTHS_NOT_UNIQUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_AUTH_IS_OWNER"
-msgstr "Ldap is disabled in config.xml for given realm"
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_AUTH_IS_OWNER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_AUTH_NOT_SET"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_AUTH_NOT_SET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_HAS_STATUS_DOES_NOT_MATCH"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_HAS_STATUS_DOES_NOT_MATCH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_HAS_STATUS_IDENTIFIER_MISSING"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_HAS_STATUS_IDENTIFIER_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_IN_STATE_CRL_ISSUANCE_PENDING"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_IN_STATE_CRL_ISSUANCE_PENDING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_IN_STATE_REVOKED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_IN_STATE_REVOKED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_NOT_ON_HOLD_AND_REASON_CODE_REMOVE_FROM_CRL"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_NOT_ON_HOLD_AND_REASON_CODE_REMOVE_FROM_CRL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_ON_HOLD_AND_REASON_CODE_NOT_REMOVE_FROM_CRL"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_CERT_ON_HOLD_AND_REASON_CODE_NOT_REMOVE_FROM_CRL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_IDENTIFIER_MISSING"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CERTIFICATE_NOT_YET_REVOKED_IDENTIFIER_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CONNECTOR_IS_VALUE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_CONNECTOR_IS_VALUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_DOES_NOT_EXIST"
-msgstr "LDAP node does not exist"
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_EQUALITY_MISMATCH"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_EQUALITY_MISMATCH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_INVALID_CONDITION"
-msgstr "Ldap is disabled in config.xml for given realm"
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_INVALID_CONDITION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_VALUE_EMPTY"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOLENTRY_VALUE_EMPTY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOL_REGEX_MISMATCH"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_DATAPOOL_REGEX_MISMATCH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_HASROLE_NO_ROLE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_HASROLE_NO_ROLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_ISSERVERKEYGENERATION_NO_SERVER_KEYGEN_PKCS10_DEFINED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_ISSERVERKEYGENERATION_NO_SERVER_KEYGEN_PKCS10_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_ISSERVERKEYGENERATION_NO_SERVER_KEYGEN_SPKAC_DEFINED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_ISSERVERKEYGENERATION_NO_SERVER_KEYGEN_SPKAC_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_KEY_UNUSABLE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_KEY_UNUSABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_MAX_ITERATIONS_REACHED"
-msgstr "Ldap is disabled in config.xml for given realm"
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_MAX_ITERATIONS_REACHED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_SCEPCLIENT_INVALID_TID"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_SCEPCLIENT_INVALID_TID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_SC_ACT_CODE_INVALID"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_SC_ACT_CODE_INVALID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WFARRAY_ARRAY_NOT_EMPTY"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WFARRAY_ARRAY_NOT_EMPTY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WFHASH_KEY_IS_EMPTY"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WFHASH_KEY_IS_EMPTY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WFHASH_KEY_NOT_DEFINED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WFHASH_KEY_NOT_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_EQUALITY_MISMATCH"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_EQUALITY_MISMATCH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_REGEX_MISMATCH"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_REGEX_MISMATCH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_VALUE_DOES_NOT_EXIST"
-msgstr "LDAP node does not exist"
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_VALUE_DOES_NOT_EXIST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_VALUE_EMPTY"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_CONTEXT_VALUE_EMPTY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_INVALID_CONDITION"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCONTEXT_INVALID_CONDITION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCREATOR_CREATOR_AND_USER_DIFFER"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_CONDITION_WORKFLOWCREATOR_CREATOR_AND_USER_DIFFER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_ERROR_ON_EXECUTE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_ERROR_ON_EXECUTE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_IS_STUB_ACTIVITY"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_IS_STUB_ACTIVITY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_IS_STUB_CONDITION"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_IS_STUB_CONDITION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_IS_STUB_VALIDATOR"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_IS_STUB_VALIDATOR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_FETCH_WORKFLOW_INCORRECT_WORKFLOW_INSTANCE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_FETCH_WORKFLOW_INCORRECT_WORKFLOW_INSTANCE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_FETCH_WORKFLOW_NOT_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_FETCH_WORKFLOW_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_NO_ID_FROM_SEQUENCE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_NO_ID_FROM_SEQUENCE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_UPDATE_WORKFLOW_CONTEXT_VALUE_ILLEGAL_DATA"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_UPDATE_WORKFLOW_CONTEXT_VALUE_ILLEGAL_DATA"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_UPDATE_WORKFLOW_CONTEXT_VALUE_TOO_BIG"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_UPDATE_WORKFLOW_CONTEXT_VALUE_TOO_BIG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_UPDATE_WORKFLOW_FETCH_WORKFLOW_FAILURE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_PERSISTER_DBI_UPDATE_WORKFLOW_FETCH_WORKFLOW_FAILURE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_COULD_NOT_DETERMINE_SIGNER_CERTIFICATE_IDENTIFIER"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_COULD_NOT_DETERMINE_SIGNER_CERTIFICATE_IDENTIFIER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_PLAIN_TEXT_DOES_NOT_MATCH_REQUIRED_STRUCTURE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_PLAIN_TEXT_DOES_NOT_MATCH_REQUIRED_STRUCTURE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_SIGNATURE_INVALID"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_SIGNATURE_INVALID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_SIGNER_NOT_TRUSTED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVALSIGNATURE_SIGNER_NOT_TRUSTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVAL_SIGNATURE_SIGNATURE_CONTAINS_INVALID_CHARACTERS"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVAL_SIGNATURE_SIGNATURE_CONTAINS_INVALID_CHARACTERS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVAL_SIGNATURE_SIGNATURE_NOT_DEFINED_BUT_REQUIRED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_APPROVAL_SIGNATURE_SIGNATURE_NOT_DEFINED_BUT_REQUIRED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_BULK_NOT_UNDEF_OR_ONE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_BULK_NOT_UNDEF_OR_ONE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERTPROFILE_PROFILE_NOT_VALID_FOR_ROLE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERTPROFILE_PROFILE_NOT_VALID_FOR_ROLE"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERTSUBJECTPARTS_DID_NOT_MATCH_REGEX"
 msgstr ""
@@ -3783,7 +3281,7 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERTSUBJECTPARTS_SELECT_DID_NOT_MATCH_OPTIONS"
-msgstr "The name __DNS__ is not a valid DNS entry."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERTSUBJECTPARTS_SELECT_DID_NOT_MATCH_OPTIONS"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERTSUBJECTPARTS_TOO_LITTLE_ELEMENTS"
 msgstr ""
@@ -3797,15 +3295,15 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERT_IDENTIFIER_EXISTS_NO_SUCH_ID"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERT_IDENTIFIER_EXISTS_NO_SUCH_ID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERT_PROFILE_UNSUPPORTED_PROFILE"
-msgstr "The IP address __IP__ is not compliant to IPv4 and IPv6."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERT_PROFILE_UNSUPPORTED_PROFILE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERT_ROLE_INVALID"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERT_ROLE_INVALID"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CERT_SUBJECT_ALT_NAME_MISSING_TYPE"
 msgstr "The type of a subject alternative name field is missing."
@@ -3838,7 +3336,7 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CONNECTOR_CHECK_FAILED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_CONNECTOR_CHECK_FAILED"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_INVALIDITYTIME_AFTER_CERT_NOTAFTER"
 msgstr ""
@@ -3851,15 +3349,15 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_INVALIDITYTIME_CERTIFICATE_NOT_FOUND_IN_DB"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_INVALIDITYTIME_CERTIFICATE_NOT_FOUND_IN_DB"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_INVALIDITYTIME_INVALID_IDENTIFIER"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_INVALIDITYTIME_INVALID_IDENTIFIER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_INVALIDITYTIME_IN_FUTURE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_INVALIDITYTIME_IN_FUTURE"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_KEYLENGTH_CONFIGURATION_ERROR_INVALID_ALGORITHM_OR_LENGTH"
 msgstr "Keylength validator configuration error: invalid algorithm or length"
@@ -3885,54 +3383,54 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_KEYREUSE_CERTIFICATE_WITH_KEY_ALREADY_EXISTS"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_KEYREUSE_CERTIFICATE_WITH_KEY_ALREADY_EXISTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PASSWORD_QUALITY_BAD_PASSWORD"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PASSWORD_QUALITY_BAD_PASSWORD"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PKCS10_DAMAGED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PKCS10_DAMAGED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PKCS10_PARSE_ERROR"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PKCS10_PARSE_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PKCS10_TOKEN_UNAVAILABLE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_PKCS10_TOKEN_UNAVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_REASON_CODE_INVALID"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_REASON_CODE_INVALID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_REGEX_FAILED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_REGEX_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_RELATIVEDATE_WRONG_TIMESPEC"
-msgstr "The IP address __IP__ is not compliant to IPv4 and IPv6."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_RELATIVEDATE_WRONG_TIMESPEC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SCPU_INVALID_AUTHID"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SCPU_INVALID_AUTHID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SPKAC_NO_BASE64"
-msgstr "The submitted SPKAC data is not correctly base 64 encoded."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SPKAC_NO_BASE64"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SPKAC_NO_DATA"
 msgstr "The SPKAC string is empty."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SPKAC_TOO_SHORT"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SPKAC_TOO_SHORT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SUBJECT_MISMATCH_PKCS10"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_SUBJECT_MISMATCH_PKCS10"
 
 msgid "I18N_OPENXPKI_SERVER_WORKFLOW_VALIDATOR_VALIDITYTIME_INVALID_CONTENT"
 msgstr "The entered date/time could not be validated."
@@ -3942,37 +3440,35 @@ msgstr "The entered date/time could not be validated."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER_XML_CACHE___GET_SUPER_ENTRY_MORE_THAN_ONE_PATH_AND_NO_ID_SPECIFIED"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_SERVER_XML_CACHE___GET_SUPER_ENTRY_MORE_THAN_ONE_PATH_AND_NO_ID_SPECIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER__DBI_DRIVER_ORACLE_GET_DSN_NO_DATABASE_NAME"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER__DBI_DRIVER_ORACLE_GET_DSN_NO_DATABASE_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER__DBI_DRIVER_ORACLE_GET_NEW_SERIAL_NO_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER__DBI_DRIVER_ORACLE_GET_NEW_SERIAL_NO_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER__DBI_DRIVER_POSTGRESQL_GET_DSN_NO_DATABASE_NAME"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER__DBI_DRIVER_POSTGRESQL_GET_DSN_NO_DATABASE_NAME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER__DBI_DRIVER_POSTGRESQL_GET_NEW_SERIAL_NO_TABLE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVER__DBI_DRIVER_POSTGRESQL_GET_NEW_SERIAL_NO_TABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVER__GET_SERVER_CONFIG_UNKNOWN_SERVER_TYPE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVER__GET_SERVER_CONFIG_UNKNOWN_SERVER_TYPE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_COLLECT_INCORRECT_COMMUNICATION_STATE"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_SERVICE_COLLECT_INCORRECT_COMMUNICATION_STATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_COLLECT_TIMEOUT"
-msgstr "A timeout occured while reading data from the CA server."
+msgstr "I18N_OPENXPKI_SERVICE_COLLECT_TIMEOUT"
 
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_COMMAND_MISSING"
 msgstr "Service error: missing command"
@@ -3982,7 +3478,7 @@ msgstr "Service error: could not instantiate command class: __EVAL_ERROR__"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_EXECUTE_COMMAND_NOT_FOUND"
-msgstr "Service error: command execution failed: __ERROR__"
+msgstr "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_EXECUTE_COMMAND_NOT_FOUND"
 
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_EXECUTION_ERROR"
 msgstr "Service error: command execution failed: __ERROR__"
@@ -3992,9 +3488,7 @@ msgstr "Service error: illegal command return value"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_IMPL_INSTANTIATE_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_IMPL_INSTANTIATE_FAILED"
 
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_INVALID_COMMAND"
 msgstr "Service error: invalid command"
@@ -4004,9 +3498,7 @@ msgstr "Service error: permission to execute command denied."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_PRIVATE_METHOD_REQUESTED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_DEFAULT_COMMAND_PRIVATE_METHOD_REQUESTED"
 
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_GET_AUTHENTICATION_STACK_INVALID_AUTH_STACK_REQUESTED"
 msgstr "Service error: invalid authentication stack requested."
@@ -4022,13 +3514,7 @@ msgstr ""
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_GET_PASSWD_USERNAME_UNDEFINED"
-msgstr ""
-"Your username contains non-ASCII characters. We currently suffer from a bug "
-"that will crash the web interface if non-ASCII characters are used (see "
-"#1903037 on our SourceForge tracker), thus we currently prevent those users "
-"from logging in. Please make sure that your users do not use non-ASCII "
-"characters in their usernames or check back with us to see if the bug has "
-"been fixed. Sorry for the inconvenience."
+msgstr "I18N_OPENXPKI_SERVICE_DEFAULT_GET_PASSWD_USERNAME_UNDEFINED"
 
 msgid "I18N_OPENXPKI_SERVICE_DEFAULT_GET_PKI_REALM_INVALID_PKI_REALM_REQUESTED"
 msgstr "Service error: invalid PKI realm requested."
@@ -4054,176 +3540,138 @@ msgstr "Service error: unrecognized service message"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_GETCACERT_NO_IDENTIFIER_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_GETCACERT_NO_IDENTIFIER_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_GETCERT_MORE_THAN_ONE_CERTIFICATE_FOUND"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_GETCERT_MORE_THAN_ONE_CERTIFICATE_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_IMPL_INSTANTIATE_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_IMPL_INSTANTIATE_FAILED"
 
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_INVALID_COMMAND"
 msgstr "SCEP service error: invalid command"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_NO_COMMAND_IMPL"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_NO_COMMAND_IMPL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_CERT_IDENTIFIER_MISSING"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_CERT_IDENTIFIER_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_CSR_SERIAL_FALLBACK_FAILED"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_CSR_SERIAL_FALLBACK_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_FAILED_TO_REGISTER_SCEP_TID"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_FAILED_TO_REGISTER_SCEP_TID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_FAILURE_BUT_NO_ERROR_CODE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_FAILURE_BUT_NO_ERROR_CODE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_GET_CERT_FAILED"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_GET_CERT_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_NO_WORKFLOW_TYPE_DEFINED"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_NO_WORKFLOW_TYPE_DEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_PARALLEL_REQUESTS_DETECTED"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_PARALLEL_REQUESTS_DETECTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_PKCS10_UNDEFINED"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_PKCS10_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_SCEP_TOKEN_MISSING"
-msgstr "The used suject style does not allow the use of a country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PKIOPERATION_SCEP_TOKEN_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PRIVATE_METHOD_REQUESTED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_COMMAND_PRIVATE_METHOD_REQUESTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_INVALID_ALGORITHM_REQUESTED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_INVALID_ALGORITHM_REQUESTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_INVALID_PROFILE_REQUESTED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_INVALID_PROFILE_REQUESTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_INVALID_REALM_REQUESTED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_INVALID_REALM_REQUESTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_INVALID_SERVER_REQUESTED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_INVALID_SERVER_REQUESTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_ENCRYPTION_ALGORITHM_RECEIVED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_ENCRYPTION_ALGORITHM_RECEIVED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_HASH_ALGORITHM_RECEIVED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_HASH_ALGORITHM_RECEIVED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_PKI_REALM_RECEIVED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_PKI_REALM_RECEIVED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_PROFILE_RECEIVED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_PROFILE_RECEIVED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_SERVER_RECEIVED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_NO_SELECT_SERVER_RECEIVED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_NO_SET_PARAMETER_RECEIVED"
-msgstr ""
-"The used subject style requires at minimum one organizational unit and two "
-"domain components."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_NO_SET_PARAMETER_RECEIVED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_RUN_COMMAND_EXECUTION_FAILED"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_RUN_COMMAND_EXECUTION_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_RUN_COULD_NOT_INSTANTIATE_COMMAND"
-msgstr "Service error: could not instantiate command class: __EVAL_ERROR__"
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_RUN_COULD_NOT_INSTANTIATE_COMMAND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_RUN_ILLEGAL_COMMAND_RETURN_VALUE"
-msgstr ""
-"The used subject style requires at minimum one organizational unit, one "
-"organization and one country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_RUN_ILLEGAL_COMMAND_RETURN_VALUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_RUN_MISSING_SERVICE_MESSAGE"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_RUN_MISSING_SERVICE_MESSAGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_RUN_READ_EXCEPTION"
-msgstr "The Country (c) is the nothing else then country."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_RUN_READ_EXCEPTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_RUN_UNRECOGNIZED_COMMAND"
-msgstr "The used suject style requires a UID plus a common name."
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_RUN_UNRECOGNIZED_COMMAND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_SCEP_RUN_UNRECOGNIZED_SERVICE_MESSAGE"
-msgstr "Service error: unrecognized service message"
+msgstr "I18N_OPENXPKI_SERVICE_SCEP_RUN_UNRECOGNIZED_SERVICE_MESSAGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SERVICE_TALK_INCORRECT_COMMUNICATION_STATE"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_SERVICE_TALK_INCORRECT_COMMUNICATION_STATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_SET_LOCALE_PREFIX_DIR_DOES_NOT_EXIST"
-msgstr "reset"
+msgstr "I18N_OPENXPKI_SET_LOCALE_PREFIX_DIR_DOES_NOT_EXIST"
 
 msgid "I18N_OPENXPKI_SUBJECT_STYLE_C_NOT_ALLOWED"
 msgstr "The used suject style does not allow the use of a country."
@@ -4249,137 +3697,129 @@ msgstr "The used suject style requires a UID plus a common name."
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TEMPLATE_PASSWORD_GENERATE_INVALID_SCHEME_SPECIFICATION"
-msgstr "The used suject style does not allow the use of an organization."
+msgstr "I18N_OPENXPKI_TEMPLATE_PASSWORD_GENERATE_INVALID_SCHEME_SPECIFICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TEMPLATE_PASSWORD_GENERATE_MISSING_SCHEME_SPECIFICATION"
-msgstr ""
-"The requested service is not available. This can happen because of a "
-"misconfiguration or simply because the service is actually not implemented. "
-"Nevertheless this is an administrative problem. Please contact the "
-"administrators."
+msgstr "I18N_OPENXPKI_TEMPLATE_PASSWORD_GENERATE_MISSING_SCHEME_SPECIFICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOKEN_CONFIG_HSM_AUTHENTICATION_GROUP"
-msgstr "Default key group"
+msgstr "I18N_OPENXPKI_TOKEN_CONFIG_HSM_AUTHENTICATION_GROUP"
 
+# Thi probably should be removed
 #, fuzzy
 msgid "I18N_OPENXPKI_TOKEN_STATUS_"
-msgstr "Status"
+msgstr "I18N_OPENXPKI_TOKEN_STATUS_"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_TOKEN_STATUS_EXPIRED"
-msgstr "expired"
+msgstr "Token expired"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_TOKEN_STATUS_OFFLINE"
-msgstr "Usable"
+msgstr "Token offline"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_TOKEN_STATUS_ONLINE"
-msgstr "Not usable"
+msgstr "Token online"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_TOKEN_STATUS_UNKNOWN"
-msgstr "Status"
+msgstr "Unknown token status"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_TOKEN_STATUS_UPCOMING"
-msgstr "Status"
+msgstr "Token upcoming"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_BINARY_NOT_EXECUTABLE"
-msgstr "Fax number"
+msgstr "I18N_OPENXPKI_TOOLKIT_BINARY_NOT_EXECUTABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_BINARY_NOT_FOUND"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_TOOLKIT_BINARY_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_COMMAND_EVAL_ERROR"
-msgstr "Common name"
+msgstr "I18N_OPENXPKI_TOOLKIT_COMMAND_EVAL_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_COMMAND_FAILED"
-msgstr "Common name"
+msgstr "I18N_OPENXPKI_TOOLKIT_COMMAND_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_COMMAND_MISSING_SUBPARAMETER_COMMAND"
-msgstr ""
-"The common name can be used to identify persons or objects by its name. "
-"Example are John Doe or www.openxpki.org."
+msgstr "I18N_OPENXPKI_TOOLKIT_COMMAND_MISSING_SUBPARAMETER_COMMAND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_COMMAND_MISSING_SUBPARAMETER_PARAMS"
-msgstr "Common name"
+msgstr "I18N_OPENXPKI_TOOLKIT_COMMAND_MISSING_SUBPARAMETER_PARAMS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_COMMAND_REQUIRE_FAILED"
-msgstr "Common name"
+msgstr "I18N_OPENXPKI_TOOLKIT_COMMAND_REQUIRE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_ENGINE_UNDEFINED"
-msgstr "uid"
+msgstr "I18N_OPENXPKI_TOOLKIT_ENGINE_UNDEFINED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_INIT_ENGINE_NEW_FAILED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_TOOLKIT_INIT_ENGINE_NEW_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_INIT_ENGINE_USE_FAILED"
-msgstr "Deutsch"
+msgstr "I18N_OPENXPKI_TOOLKIT_INIT_ENGINE_USE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_INIT_SHELL_USE_FAILED"
-msgstr "Logout failed"
+msgstr "I18N_OPENXPKI_TOOLKIT_INIT_SHELL_USE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_INSTANTIATE_CLI_FAILED"
-msgstr "List instances"
+msgstr "I18N_OPENXPKI_TOOLKIT_INSTANTIATE_CLI_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_MISSING_COMMAND_PARAM"
-msgstr "Common name"
+msgstr "I18N_OPENXPKI_TOOLKIT_MISSING_COMMAND_PARAM"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TOOLKIT_TEMPORARY_DIRECTORY_UNAVAILABLE"
-msgstr "Trustcenter Web Interface"
+msgstr "I18N_OPENXPKI_TOOLKIT_TEMPORARY_DIRECTORY_UNAVAILABLE"
 
+# This probably should be removed
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT"
-msgstr "Organizational Unit"
+msgstr "I18N_OPENXPKI_TRANSPORT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_NEW_OPEN_INFILE_FAILED"
-msgstr "CSR with DC-style"
+msgstr "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_NEW_OPEN_INFILE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_NEW_OPEN_OUTFILE_FAILED"
-msgstr "CSR with DC-style"
+msgstr "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_NEW_OPEN_OUTFILE_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_CLOSED_CONNECTION"
-msgstr "CSR with DC-style"
+msgstr "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_CLOSED_CONNECTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_DAMAGED_MESSAGE"
-msgstr "CSR with DC-style"
+msgstr "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_DAMAGED_MESSAGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_FAILED"
-msgstr "CSR with DC-style"
+msgstr "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_FAILED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_WRONG_MESSAGE_TYPE"
-msgstr "CSR with DC-style"
+msgstr "I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_WRONG_MESSAGE_TYPE"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_WRITE_ERROR_DURING___SEND"
-msgstr "CSR with OU-style"
+msgstr ""
+"__send() failed in OpenXPKI::Transport::Simple::write()  (error: "
+"__EVAL_ERROR__)"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_TRANSPORT_SIMPLE_WRITE_MISSING_OK"
-msgstr "CSR with OU-style"
+msgstr "I18N_OPENXPKI_TRANSPORT_SIMPLE_WRITE_MISSING_OK"
 
 msgid "I18N_OPENXPKI_UI_ACTION_NOT_FOUND"
 msgstr "Requested action not found"
@@ -4393,9 +3833,10 @@ msgstr "Backend session terminated - please re-login"
 msgid "I18N_OPENXPKI_UI_CERT_IDENTIFIER"
 msgstr "Certificate ID"
 
+# Remove?
 #, fuzzy
 msgid "I18N_OPENXPKI_UI_CERT_STATUS_"
-msgstr "State"
+msgstr "I18N_OPENXPKI_UI_CERT_STATUS_"
 
 msgid "I18N_OPENXPKI_UI_CERT_STATUS_CRL_PENDING"
 msgstr "revocation pending"
@@ -4451,16 +3892,18 @@ msgstr "Key length"
 msgid "I18N_OPENXPKI_UI_KEYGEN_PARAM_PARAMSET"
 msgstr "Parameters"
 
+# Remove?
 #, fuzzy
 msgid "I18N_OPENXPKI_UI_KEY_"
-msgstr "Username"
+msgstr "I18N_OPENXPKI_UI_KEY_"
 
 msgid "I18N_OPENXPKI_UI_KEY_ALG"
 msgstr "Key algorithm"
 
+# Remove?
 #, fuzzy
 msgid "I18N_OPENXPKI_UI_KEY_ALG_"
-msgstr "Username"
+msgstr "I18N_OPENXPKI_UI_KEY_ALG_"
 
 msgid "I18N_OPENXPKI_UI_KEY_ALG_DSA"
 msgstr "DSA (Signature only)"
@@ -4495,9 +3938,10 @@ msgstr "Curve sect571r1"
 msgid "I18N_OPENXPKI_UI_KEY_ENC"
 msgstr "Encryption"
 
+# Remove?
 #, fuzzy
 msgid "I18N_OPENXPKI_UI_KEY_ENC_"
-msgstr "Username"
+msgstr "I18N_OPENXPKI_UI_KEY_ENC_"
 
 msgid "I18N_OPENXPKI_UI_KEY_ENC_3DES"
 msgstr "3DES"
@@ -4541,232 +3985,146 @@ msgstr "Please choose a profile"
 msgid "I18N_OPENXPKI_UI_PROFILE_CHOOSE_PROFILE_FIRST"
 msgstr "Please select profile first"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_CN_DESC"
-msgstr ""
-"Choose this style if you know exactly how your certificate subject is "
-"supposed to look like and have a good understanding of the certificate "
-"subject components and your local naming conventions. It also allows you to "
-"set arbitrary subject alternative names."
+msgstr "Common Name"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_COMMENT"
 msgstr "Comment"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_COMMENT_DESC"
-msgstr "For information for the registration officers"
+msgstr "Comment"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_C_DESC"
-msgstr ""
-"Choose this style if you know exactly how your certificate subject is "
-"supposed to look like and have a good understanding of the certificate "
-"subject components and your local naming conventions. It also allows you to "
-"set arbitrary subject alternative names."
+msgstr "Country"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_DC_DESC"
-msgstr ""
-"Choose this style if you know exactly how your certificate subject is "
-"supposed to look like and have a good understanding of the certificate "
-"subject components and your local naming conventions. It also allows you to "
-"set arbitrary subject alternative names."
+msgstr "Domain Component"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_DEPARTMENT"
 msgstr "Department"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_DEPARTMENT_DESC"
-msgstr "The (TCP) port that is used with the certificate"
+msgstr "Department"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_EMAILADDRESS"
 msgstr "E-mail:"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_EMAILADDRESS_DESC"
-msgstr "Your e-mail address, for example john.doe@example.com"
+msgstr "Email address"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_HOSTNAME"
 msgstr "Hostname"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_HOSTNAME_DESC"
-msgstr "This is the (fully qualified) hostname"
+msgstr "Host name"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_OU_DESC"
-msgstr "User profile"
+msgstr "Organizational Unit"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_O_DESC"
-msgstr ""
-"Choose this style if you know exactly how your certificate subject is "
-"supposed to look like and have a good understanding of the certificate "
-"subject components and your local naming conventions. It also allows you to "
-"set arbitrary subject alternative names."
+msgstr "Organization name"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_PHONE"
 msgstr "Phone"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_PHONE_DESC"
-msgstr ""
-"Choose this style if you know exactly how your certificate subject is "
-"supposed to look like and have a good understanding of the certificate "
-"subject components and your local naming conventions. It also allows you to "
-"set arbitrary subject alternative names."
+msgstr "Phone number"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_PORT"
 msgstr "Port"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_PORT_DESC"
-msgstr "The (TCP) port that is used with the certificate"
+msgstr "Port number"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_REALNAME"
 msgstr "Realname"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_REALNAME_DESC"
-msgstr "Your real name, for example 'John Doe'"
+msgstr "Real name"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_AFFILIATION"
 msgstr "Affiliation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_AFFILIATION_DESC"
-msgstr ""
-"If you use this style, you'll only be required to enter your name, username "
-"and e-mail address. This is the easiest way to obtain a certificate, use it "
-"if you have no specific requirement for which you would need the advanced "
-"style."
+msgstr "Requestor affiliation"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_EMAIL"
 msgstr "Email address"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_EMAIL_DESC"
-msgstr ""
-"If you use this style, you'll only be required to enter your name, username "
-"and e-mail address. This is the easiest way to obtain a certificate, use it "
-"if you have no specific requirement for which you would need the advanced "
-"style."
+msgstr "Requestor email"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_FIRSTNAME"
 msgstr "Firstname"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_FIRSTNAME_DESC"
-msgstr "This is the (fully qualified) hostname"
+msgstr "Requestor first name"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_LASTNAME"
 msgstr "Lastname"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_REQUESTOR_LASTNAME_DESC"
-msgstr "This is the (fully qualified) hostname"
+msgstr "Requestor last name"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_DNS"
 msgstr "DNS"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_DNS_DESCRIPTION"
-msgstr ""
-"A DNS name is the human readable name of a machine. Example: www.openxpki."
-"org."
+msgstr "DNS server"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_EMAIL"
 msgstr "emailAddress"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_EMAIL_DESCRIPTION"
-msgstr ""
-"This field can contain an email address. Email addresses should not be "
-"included in the name of the certificate (subject). Therefore you should add "
-"it to the subject alternative name. You can add several different email "
-"addresses to the subject alternative name but please add only one address "
-"per form field."
+msgstr "Email"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_FREE"
 msgstr "Subj. Alt. Name"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_FREE_DESCRIPTION"
-msgstr "No description available today."
+msgstr "Free"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_GUID"
 msgstr "Microsoft GUID"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_GUID_DESCRIPTION"
-msgstr ""
-"Microsoft GUID which is compatible with the UUID of RFC 4122 is used to "
-"identify machines like domain controllers. If you need a certificate for a "
-"domain controller then you must specify the GUID or it will not work."
+msgstr "GUID"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_IP"
 msgstr "IP Address"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_IP_DESCRIPTION"
-msgstr ""
-"The IP address is the real address of any computer. An IPv4 address looks "
-"like 123.123.123.123 and IPv6 address looks like 11ad::de01:adf. This field "
-"should be filled if you request a certificate for a server because sometimes "
-"the server will be addressed directly by its IP address and not by its DNS "
-"name. If this happens then the DNS entries in the subject alternative name "
-"does not help."
+msgstr "IP address"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_RID"
-msgstr "User profile"
+msgstr "RID"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_RID_DESCRIPTION"
-msgstr "No description available today."
+msgstr "IRID"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_UPN"
 msgstr "UPN"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_UPN_DESCRIPTION"
-msgstr ""
-"The Microsoft Universal Prinicipal Name (UPN) looks like an email address "
-"but it is no email address. It is the account plus the domain. Example: "
-"testuser@openxpki.org. Here it is the account testuser of the domain "
-"openxpki.org. Please see Microsoft's documentation if you need more "
-"information. Their whitepapers are really good in this case."
+msgstr "UPN"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_URI"
 msgstr "URI"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_SAN_URI_DESCRIPTION"
-msgstr ""
-"Uniform Ressource Identifier (URI) can be any address or reference to an "
-"information source. Example: http://www.openxpki.org/~testuser/."
+msgstr "URI"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_USERID"
 msgstr "User ID"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_USERID_DESC"
-msgstr ""
-"If you use this style, you'll only be required to enter your name, username "
-"and e-mail address. This is the easiest way to obtain a certificate, use it "
-"if you have no specific requirement for which you would need the advanced "
-"style."
+msgstr "User ID"
 
 msgid "I18N_OPENXPKI_UI_PROFILE_USERNAME"
 msgstr "Username"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_UI_PROFILE_USERNAME_DESC"
-msgstr ""
-"If you use this style, you'll only be required to enter your name, username "
-"and e-mail address. This is the easiest way to obtain a certificate, use it "
-"if you have no specific requirement for which you would need the advanced "
-"style."
+msgstr "Username"
 
 msgid "I18N_OPENXPKI_UI_UNKNOWN_ERROR"
 msgstr "Unknown error"
@@ -4806,123 +4164,97 @@ msgstr "Your username or account, for example 'jdoe'"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WATCHDOG_RUN_TOO_MANY_INSTANCES"
-msgstr "Create a new workflow instance for certificate issuance"
+msgstr "I18N_OPENXPKI_WATCHDOG_RUN_TOO_MANY_INSTANCES"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WFOBJECT_DESERIALIZE_ERR"
-msgstr "Serial"
+msgstr "I18N_OPENXPKI_WFOBJECT_DESERIALIZE_ERR"
 
+# Remove?
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_ACL_"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_APPROVE_CSR"
 msgstr "Approve CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CANCEL_CSR_APPROVAL"
 msgstr "Cancel CSR approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_CSR_INFO"
-msgstr "Change additional information"
+msgstr "Change CSR info"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_CSR_PROFILE"
-msgstr "Change certificate profile"
+msgstr "Change CSR profile"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_CSR_ROLE"
-msgstr "Change role"
+msgstr "Change CSR role"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_CSR_SUBJECT"
-msgstr "Change subject"
+msgstr "Change CSR subject"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_CSR_SUBJECT_ALT_NAME"
-msgstr "Change subject alternative name"
+msgstr "Change CSR subject alternative name"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_CSR_SUBJECT_STYLE"
-msgstr "Change subject style"
+msgstr "Change CSR subject style"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_NOTAFTER"
-msgstr "Change notafter date"
+msgstr "Change \"not after\""
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_NOTBEFORE"
-msgstr "Change notbefore date"
+msgstr "Change  \"not before\""
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CHANGE_PASSWORD"
-msgstr "Change additional information"
+msgstr "Change password"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CREATE_CSR"
-msgstr "Reject CSR"
+msgstr "Create CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CRR_APPROVE"
-msgstr "Cancel CRR approval"
+msgstr "Create CRR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CRR_CANCEL_APPROVAL"
 msgstr "Cancel CRR approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CRR_CHANGE_INVALIDITY_TIME"
-msgstr "Change CRR invalidity time"
+msgstr "Change CRR validity time"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CRR_CHANGE_REASON"
 msgstr "Change CRR reason"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CRR_CREATE"
-msgstr "Reject CRR"
+msgstr "Create CRR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CRR_INSERT"
-msgstr "Reject CSR"
+msgstr "Insert CRR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_CRR_REJECT"
 msgstr "Reject CRR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_FAIL_WORKFLOW"
 msgstr "Fail workflow"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_INSERT_CSR"
-msgstr "Export CSR"
+msgstr "Insert CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_PERSIST_CSR"
 msgstr "Persist CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_REJECT_CSR"
 msgstr "Reject CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_RETRIEVE_PASSWORD"
-msgstr "CRL Issuance"
+msgstr "Retrieve password"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_REVOKE_CERTIFICATE"
-msgstr "Revoke the certificate"
+msgstr "Revoke certificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_SMARTCARD_PERSONALIZATION"
-msgstr "Personalize a smartcard"
+msgstr "SmartCard personalization"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACL_STORE_PASSWORD"
-msgstr "CRL Issuance"
+msgstr "Store password"
 
 msgid "I18N_OPENXPKI_WF_ACTION_APPROVE_CRR"
 msgstr "Approve CRR"
@@ -4930,9 +4262,8 @@ msgstr "Approve CRR"
 msgid "I18N_OPENXPKI_WF_ACTION_APPROVE_CSR"
 msgstr "Approve CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CANCEL_APPROVAL"
-msgstr "Cancel CRR approval"
+msgstr "Cancel approval"
 
 msgid "I18N_OPENXPKI_WF_ACTION_CANCEL_CRR_APPROVAL"
 msgstr "Cancel CRR approval"
@@ -4940,13 +4271,11 @@ msgstr "Cancel CRR approval"
 msgid "I18N_OPENXPKI_WF_ACTION_CANCEL_CSR_APPROVAL"
 msgstr "Cancel CSR approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CERTIFICATE_PUBLISHING_INITIALIZE"
-msgstr "Create a new workflow instance for publishing a certificate using LDAP"
+msgstr "Initialize"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CERTIFICATE_PUBLISHING_PUBLISH"
-msgstr "Create a new workflow instance for publishing a certificate using LDAP"
+msgstr "Publish certificate"
 
 msgid "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_ABORT"
 msgstr "discard changes"
@@ -4981,56 +4310,46 @@ msgstr "Change notafter date"
 msgid "I18N_OPENXPKI_WF_ACTION_CHANGE_NOTBEFORE"
 msgstr "Change notbefore date"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CREATE_CRR"
-msgstr "Reject CRR"
+msgstr "Create CRR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CREATE_QUEUE"
-msgstr "Reject CRR"
+msgstr "Create queue"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CRL_ISSUANCE_PUBLISH_CRL"
-msgstr "Persist CSR"
+msgstr "Publish CRL"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CSR_GENERATE_KEY"
-msgstr "Sleep"
+msgstr "Generate key"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CSR_GENERATE_PKCS10"
-msgstr "Export CSR"
+msgstr "Generate PKCS10"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CYCLE_SUB_FORK"
-msgstr "Change additional information"
+msgstr "I18N_OPENXPKI_WF_ACTION_CYCLE_SUB_FORK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_CYCLE_TOP_FORK"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_ACTION_CYCLE_TOP_FORK"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_DELAY_REVOCATION"
-msgstr "Sleep"
+msgstr "Delay revocation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_DO_NOTHING"
-msgstr "Sleep"
+msgstr "Do nothing"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_DO_NOTHING2"
-msgstr "Sleep"
+msgstr "Do nothing (2)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_DO_NOTHING3"
-msgstr "Sleep"
+msgstr "Do nothing (3)"
 
 msgid "I18N_OPENXPKI_WF_ACTION_EXPORT_CRR"
 msgstr "Export CRR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_GET_NEXT_CA"
-msgstr "(internal) determine next CA"
+msgstr "Get next CA"
 
 msgid "I18N_OPENXPKI_WF_ACTION_METADATA_LOAD_DATA"
 msgstr "change metadata"
@@ -5044,80 +4363,59 @@ msgstr "persist metadata"
 msgid "I18N_OPENXPKI_WF_ACTION_METADATA_UPDATE_DATA"
 msgstr "save input"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NICE_CHECK_FOR_REVOCATION"
-msgstr "Change CRR reason"
+msgstr "Check for revocation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NICE_FETCH_CERTIFICATE"
-msgstr "Revoke the certificate"
+msgstr "Fetch certificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NICE_INIT_ISSUE_CRL"
-msgstr "Persist CSR"
+msgstr "Issue CRL"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NICE_ISSUE_CERTIFICATE"
-msgstr "Revoke the certificate"
+msgstr "Issue certificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NICE_ISSUE_CRL"
-msgstr "Persist CSR"
+msgstr "Issue CRL"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NICE_RENEW_CERTIFICATE"
-msgstr "Revoke the certificate"
+msgstr "Renew cerificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NICE_REVOKE_CERTIFICATE"
-msgstr "Revoke the certificate"
+msgstr "Revoke certificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NOTIFY_APPROVAL"
-msgstr "Cancel CRR approval"
+msgstr "Notify approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NOTIFY_USER_OF_CREATION"
-msgstr "Change CRR reason"
+msgstr "Notify user of creation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_NOTIFY_USER_OF_ISSUANCE"
-msgstr "Create a new workflow instance for certificate issuance"
+msgstr "Notify user of issuance"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_PASSWORD_SAFE_CHANGE_PASSWORD"
-msgstr "Change additional information"
+msgstr "Change password"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_PASSWORD_SAFE_RETRIEVE_PASSWORD"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Retrieve password"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_PASSWORD_SAFE_STORE_PASSWORD"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "Store password"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_PAUSE"
-msgstr "Sleep"
+msgstr "Pause"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_PERSIST_CRR"
-msgstr "Persist CSR"
+msgstr "Persist CRR"
 
 msgid "I18N_OPENXPKI_WF_ACTION_PERSIST_CSR"
 msgstr "Persist CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_PERSIST_METADATA"
-msgstr "Persist CSR"
+msgstr "Persist metadata"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_PUBLISH_CERTIFICATE"
-msgstr "Revoke the certificate"
+msgstr "Publish certificate"
 
 msgid "I18N_OPENXPKI_WF_ACTION_REJECT_CRR"
 msgstr "Reject CRR"
@@ -5125,130 +4423,101 @@ msgstr "Reject CRR"
 msgid "I18N_OPENXPKI_WF_ACTION_REJECT_CSR"
 msgstr "Reject CSR"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_RENDER_SUBJECT"
-msgstr "Change subject"
+msgstr "Render subject"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_RENEW_FETCH_ORG_CERT_DATA"
-msgstr "Wait for other workflow instance"
+msgstr "Fetch org cert data"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_RENEW_SET_DATA"
-msgstr "Sleep"
+msgstr "Set data"
 
 msgid "I18N_OPENXPKI_WF_ACTION_REVOKE_CERTIFICATE"
 msgstr "Revoke the certificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_TEST"
-msgstr "Sleep"
+msgstr "Test"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_TEST_ACTIVITY"
-msgstr "Persist CSR"
+msgstr "Test activity"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_TEST_NOTIFY1"
-msgstr "Persist CSR"
+msgstr "Test notify1"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_TOOLS_CERTIFICATE_IDENTIFIER_FROM_CERTIFICATE"
-msgstr ""
-"No certificates requested by you have been found. If you want to request a "
-"new certificate, please use the Request menu."
+msgstr "Certificate identifier from cert"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_TOOLS_CERTIFICATE_IDENTIFIER_FROM_SUBJECT"
-msgstr "Revoke the certificate"
+msgstr "Certificate identifier from subject"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_TOOLS_DISCONNECT"
-msgstr "Continue"
+msgstr "Disconnect"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_TOOLS_SERIAL_FROM_CERTIFICATE"
-msgstr "Revoke the certificate"
+msgstr "Serial from certificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_VICE_GET_CREDITS"
-msgstr "Persist CSR"
+msgstr "Get credits"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_VICE_PERSIST_CREDITS"
-msgstr "Persist CSR"
+msgstr "Persist credits"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_ACTION_WORKFLOWTEST"
-msgstr "Fail workflow"
+msgstr "Workflow test"
 
+# Remove?
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_COND_"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_CERTIFICATE_NOT_YET_REVOKED"
-msgstr "Revoke the certificate"
+msgstr "Not yet revoked"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_CERTIFICATE_NOT_YET_REVOKED_OR_PENDING"
-msgstr "The SPKAC string is empty."
+msgstr "I1Not yet revoked or pending"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_CERTIFICATE_REVOCATION_CRL_ISSUANCE_PENDING"
-msgstr "Pending (in editing state)"
+msgstr "CRL issuance pending"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_CHECK_CRR_APPROVALS"
-msgstr "Cancel CRR approval"
+msgstr "Check CRR approvals"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_CHECK_CSR_APPROVALS"
-msgstr "Cancel CSR approval"
+msgstr "Check CSR approvals"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_CHECK_FOR_REVOCATION_CHECKS_LEFT"
-msgstr "Handle a certificate revocation request"
+msgstr "Check for revocation checks left"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_CRL_SIGNING_NO_CAS_LEFT"
-msgstr "Change role"
+msgstr "No CAS left"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_DELAYED_REVOCATION"
-msgstr "Change CRR reason"
+msgstr "Delayed revocation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_IS_AUTOAPPROVAL"
-msgstr "Cancel CSR approval"
+msgstr "Is autoapproval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_IS_WORKFLOW_CREATOR"
-msgstr "Fail workflow"
+msgstr "Is workflow creator"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_NICE_CERTIFICATE_ISSUED"
-msgstr "Issue a certificate"
+msgstr "Certificate issued"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_NICE_CERTIFICATE_PENDING"
-msgstr "Revoke the certificate"
+msgstr "Certification pending"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_SERVER_KEY_GENERATION"
-msgstr "Change CRR reason"
+msgstr "Server key generation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_COND_SUBJECT_MATCHES_PKCS10"
-msgstr "Export CSR"
+msgstr "Subject matches PKCS10"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_CERTIFICATE_PUBLISHING"
-msgstr "Publish a certificate using LDAP"
+msgstr "Certificate publishing"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_CERTIFICATE_RENEWAL_REQUEST"
-msgstr "Handle a certificate revocation request"
+msgstr "Certificate Renewal Request"
 
 msgid "I18N_OPENXPKI_WF_DESC_CERTIFICATE_REVOCATION_REQUEST"
 msgstr "Handle a certificate revocation request"
@@ -5256,9 +4525,8 @@ msgstr "Handle a certificate revocation request"
 msgid "I18N_OPENXPKI_WF_DESC_CERTIFICATE_SIGNING_REQUEST"
 msgstr "Handle a certificate signing request"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_CERT_EXPORT"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Certificate export"
 
 msgid "I18N_OPENXPKI_WF_DESC_CHANGE_METADATA"
 msgstr ""
@@ -5270,77 +4538,65 @@ msgstr "Issue a certificate revocation list (CRL)"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_CYCLE_SUB"
-msgstr "This is the workflow to issue fresh CRLs."
+msgstr "I18N_OPENXPKI_WF_DESC_CYCLE_SUB"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_CYCLE_SUB2"
-msgstr "This is the workflow to issue fresh CRLs."
+msgstr "I18N_OPENXPKI_WF_DESC_CYCLE_SUB2"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_CYCLE_TOP"
-msgstr "This is the workflow to issue fresh CRLs."
+msgstr "I18N_OPENXPKI_WF_DESC_CYCLE_TOP"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_ENROLLMENT"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Enrollment"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_PASSWORD_SAFE"
-msgstr "Issue a certificate revocation list (CRL)"
+msgstr "I18N_OPENXPKI_WF_DESC_PASSWORD_SAFE"
 
 msgid "I18N_OPENXPKI_WF_DESC_SCEP_REQUEST"
 msgstr "Handle a SCEP Certificate Signing Request"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_SMARTCARD_PERSONALIZATION_V4"
-msgstr "Personalize a smartcard"
+msgstr "SmartCard personalization"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_SMARTCARD_PIN_UNBLOCK"
-msgstr "Personalize a smartcard"
+msgstr "Unblock SmartCard PIN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_DESC_VICE_CREDITS"
-msgstr "Handle a SCEP Certificate Signing Request"
+msgstr "I18N_OPENXPKI_WF_DESC_VICE_CREDITS"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_PUBLISHING_INITIAL"
-msgstr "Initializing ..."
+msgstr "Initial state"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_PUBLISHING_PUBLISH"
-msgstr "Create a new workflow instance for publishing a certificate using LDAP"
+msgstr "Publish"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_REVOCATION_REQUEST_APPROVAL"
-msgstr "Approval is going on"
+msgstr "CRR Approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_REVOCATION_REQUEST_AUTOAPPROVAL"
-msgstr "Approval is going on"
+msgstr "CRR Autoapprocal"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_REVOCATION_REQUEST_CHECK_APPROVALS"
-msgstr "Approval is going on"
+msgstr "Check CRR approvals"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_REVOCATION_REQUEST_EDIT_REQUEST"
-msgstr "Pending (in editing state)"
+msgstr "Edit CRR request"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_REVOCATION_REQUEST_INITIAL"
-msgstr "Initializing ..."
+msgstr "CRR initial state"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_REVOCATION_REQUEST_PENDING"
-msgstr "Pending (in editing state)"
+msgstr "CRR pending"
 
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_SIGNING_REQUEST_APPROVAL"
 msgstr "Approval is going on"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_SIGNING_REQUEST_INITED"
-msgstr "Initializing ..."
+msgstr "CSR initialized"
 
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_SIGNING_REQUEST_INITIAL"
 msgstr "Initializing ..."
@@ -5348,49 +4604,38 @@ msgstr "Initializing ..."
 msgid "I18N_OPENXPKI_WF_STATE_CERTIFICATE_SIGNING_REQUEST_PENDING"
 msgstr "Pending (in editing state)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_CHECK_EXPORT"
-msgstr "Export"
+msgstr "Check export"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_CHECK_TAGGING"
-msgstr "Approve CSR"
+msgstr "Check tagging"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_CHECK_TRANSFER"
-msgstr "Export CRR"
+msgstr "Check transfer"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_EXPORT_DONE"
-msgstr "Approve CSR"
+msgstr "Export done"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_FAILURE"
-msgstr "Export CSR"
+msgstr "Export failure"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_INITIAL"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Export initial state"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_INITIALIZED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Export initialized"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_READY_TO_PROCESS"
-msgstr "Export CSR"
+msgstr "Export ready to process"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_READY_TO_TRANSFER"
-msgstr "Approve CSR"
+msgstr "Export ready to transfer"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_SUCCESS"
-msgstr "Export CSR"
+msgstr "Export successful"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CERT_EXPORT_TRANSFER_DONE"
-msgstr "Approve CSR"
+msgstr "Export transfer done"
 
 msgid "I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_CHOOSE_ACTION"
 msgstr ""
@@ -5399,9 +4644,8 @@ msgstr ""
 "update will show the form again while save will persist the data and finish "
 "the workflow."
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_FAILURE"
-msgstr "Adding missing node"
+msgstr "Metadata change failure"
 
 msgid "I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_INITIAL"
 msgstr ""
@@ -5409,9 +4653,8 @@ msgstr ""
 "identifier of the certificate.<br/>If you do not know the identifier, please "
 "use the certificate search to find it."
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_LOADED"
-msgstr "Adding missing node"
+msgstr "Metadata loaded"
 
 msgid "I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_SUCCESS"
 msgstr "The certificates metadata was updated."
@@ -5419,658 +4662,604 @@ msgstr "The certificates metadata was updated."
 msgid "I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_UPDATE"
 msgstr "update the metadata"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CRL_ISSUANCE_CREATE_QUEUE"
-msgstr "CRL issued"
+msgstr "Create queue"
 
 msgid "I18N_OPENXPKI_WF_STATE_CRL_ISSUANCE_INITIAL"
 msgstr "Initializing ..."
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CRL_ISSUANCE_ISSUE_CRL"
-msgstr "CRL issued"
+msgstr "Issue CRL"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CRL_ISSUANCE_LOAD_NEXT_CA"
-msgstr "Next CA determined"
+msgstr "Load next CA"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CRL_ISSUANCE_PUBLISH_CRL"
-msgstr "CRL published"
+msgstr "Publish CRL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CYCLE_SUB2_INITIAL"
-msgstr "Initializing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_CYCLE_SUB2_INITIAL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CYCLE_SUB_INITIAL"
-msgstr "Initializing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_CYCLE_SUB_INITIAL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_CYCLE_TOP_INITIAL"
-msgstr "Initializing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_CYCLE_TOP_INITIAL"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_DESC_APPROVAL"
-msgstr "Cancel CSR approval"
+msgstr "Approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_DESC_APPROVED"
-msgstr "Approve CSR"
+msgstr "Approved"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_AFTER_REVOKE_QUEUE"
-msgstr "SCEP Certificate Signing Request"
+msgstr "After revoke queue"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_APPROVAL"
-msgstr "Cancel CSR approval"
+msgstr "Approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_APPROVALS_CALCULATED"
-msgstr "Cancel CSR approval"
+msgstr "Approvals calculated"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_APPROVED"
-msgstr "Approve CSR"
+msgstr "Approved"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_AUTHENTICATED_REQUEST"
-msgstr "CRL issued"
+msgstr "Request authenticated"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_AUTHENTICATION"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Enrollment authentication"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_AUTHENTICATION_MISSING"
-msgstr "Basic user naming style"
+msgstr "Enrollment authentication missing"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_AUTO_REVOKE_EXISTING_CERTS"
-msgstr "Revoke the certificate"
+msgstr "Auto-revoke existing certs"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CA_KEY_NOT_USABLE"
-msgstr "SCEP Certificate Signing Request"
+msgstr "CA key not usable"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CA_KEY_USABLE"
-msgstr "SCEP Certificate Signing Request"
+msgstr "CA key usable"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CA_POLICY_APPROVAL"
-msgstr "Cancel CSR approval"
+msgstr "CA policy approval"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CERT_ISSUED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Certificate issued"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CERT_METADATA_PERSISTED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Certificate metadata persisted"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CERT_TO_REVOKE"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Certificate to revoke"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_CA_KEY"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Check CA key"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_FOR_CHALLENGE_PASSWORD"
-msgstr "Change additional information"
+msgstr "Check for challenge password"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_FOR_VALID_REQUEST"
-msgstr "Checking if DN exists in LDAP tree"
+msgstr "Check for valid request"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_INITIAL_ENROLL_AUTHEN"
-msgstr "Initializing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_INITIAL_ENROLL_AUTHEN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_RENEWAL_ELIGIBILITY"
-msgstr "Prepared for issuing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_RENEWAL_ELIGIBILITY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_RENEWAL_TYPE"
-msgstr "Prepared for issuing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CHECK_RENEWAL_TYPE"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CLEANUP"
-msgstr "SCEP Certificate Signing Request"
+msgstr "IEnrollment cleanup"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CLEAR_APPROVALS"
-msgstr "Cancel CSR approval"
+msgstr "Clear approvals"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_CONTINUE_INITIAL_ENROLL"
-msgstr "Initializing ..."
+msgstr "Continue initial enroll"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_ELIGIBLE_FOR_INITIAL_ENROLL"
-msgstr "Initializing ..."
+msgstr "Eligible for initial enroll"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_EVAL_ELIGIBILITY"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Eval eligibility"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_EVAL_SIGNER_TRUST"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Eval signer trust"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_FAILURE"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Enrollment failuer"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_FINISHED_PERSIST"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Enrollment finished persist"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_HAVE_CERT_TO_REVOKE"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Have certificate to revoke"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_HAVE_VALID_REQUEST"
-msgstr "Handle a certificate revocation request"
+msgstr "Have valid request"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_INITIAL"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Enrollment initial state"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_INITIALIZED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Enrollment initialized"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_ISSUANCE"
-msgstr "CRL Issuance"
+msgstr "Enrollment issuance"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_NOTIFIED_CERT_ISSUED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Notified certificate issuer"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_PENDING_APPROVAL"
-msgstr "Cancel CSR approval"
+msgstr "Approval pending"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_PENDING_MANUAL_AUTHENTICATION"
-msgstr "This is the normal user authentication."
+msgstr "Manual authentication pending"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_PERSISTENCE"
-msgstr "SCEP Certificate Signing Request"
+msgstr "IEnrollment persistence"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_POLICY_PENDING"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Pending enrollment policy"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_PREPARED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Prepared"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_QUEUED_FOR_REVOCATION"
-msgstr "Change CRR reason"
+msgstr "Queued for revocation"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_READY_TO_PROCESS"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Ready to process"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_ENROLLMENT_SUCCESS"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Enrollment successful"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_OGFLOW_INITIALIZED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "OGFLOW initialized"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SCEP_INITIAL_ENROLLMENT"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Initial SCEP enrollment"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SCEP_RENEWAL"
-msgstr "SCEP Certificate Signing Request"
+msgstr "SCEP renewal"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SCEP_RENEWAL_ALLOWED"
-msgstr "SCEP Certificate Signing Request"
+msgstr "ISCEP reneval allowed"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SCEP_RENEWAL_OR_SCEP_CLIENT"
-msgstr "SCEP Certificate Signing Request"
+msgstr "SCEP reneval or client"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SCEP_REQUEST_INITIAL"
-msgstr "SCEP Certificate Signing Request"
+msgstr "SCEP request initial statue"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_APPROVAL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_APPROVAL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_BEGIN_LOOP_NEED_CSR"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_BEGIN_LOOP_NEED_CSR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CAN_ISSUE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CAN_ISSUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTIFICATE_ISSUANCE_DONE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTIFICATE_ISSUANCE_DONE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTIFICATE_ISSUANCE_POSSIBLE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTIFICATE_ISSUANCE_POSSIBLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_DELETED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_DELETED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_PUBLISHED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_PUBLISHED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_DELETION"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_DELETION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_DEPUBLICATION"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_DEPUBLICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_PUBLICATION"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_PUBLICATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_REVOCATION"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERTS_QUEUED_FOR_REVOCATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_DELETE_CHECK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_DELETE_CHECK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_ID_TO_PUBLISH"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_ID_TO_PUBLISH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_INST_CHECK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_INST_CHECK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_IN_DATAPOOL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_IN_DATAPOOL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_ISSUED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_ISSUED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_PUBLISH_CHECK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_PUBLISH_CHECK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_QUEUED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_QUEUED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_RETRIEVED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_RETRIEVED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_DELETE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_DELETE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_INSTALL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_INSTALL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_PUBLISH"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_PUBLISH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_REVOKE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_REVOKE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_UNPUBLISH"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_TO_UNPUBLISH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_UNPUB_CHECK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CERT_UNPUB_CHECK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CSRS_TO_PROCESS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CSRS_TO_PROCESS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CSR_AVAIL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CSR_AVAIL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CSR_DONE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_CSR_DONE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_ESCROW_CERT_TO_INSTALL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_ESCROW_CERT_TO_INSTALL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_EXPORT_QUEUE_ENC"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_EXPORT_QUEUE_ENC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_EXPORT_QUEUE_SIG"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_EXPORT_QUEUE_SIG"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_FAILURE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_FAILURE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_FETCH_CERTIFICATE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_FETCH_CERTIFICATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_GET_NEXT_NEED_CSR"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_GET_NEXT_NEED_CSR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_DELETE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_DELETE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_PUBLISH"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_PUBLISH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_REVOKE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_REVOKE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_UNPUBLISH"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_CERT_TO_UNPUBLISH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_COMPUTED_PUK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_COMPUTED_PUK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_GENERATED_PUK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_GENERATED_PUK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_NEXT_NEED_CSR"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_NEXT_NEED_CSR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_PREREQS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_PREREQS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_PUK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_PUK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_WRITABLE_PUK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_HAVE_WRITABLE_PUK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_INITIAL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_INITIAL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_INITIALIZED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_INITIALIZED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_INSTALL_CERTIFICATE_DONE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_INSTALL_CERTIFICATE_DONE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_ISSUE_CERT"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_ISSUE_CERT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_KEY_ESCROWED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_KEY_ESCROWED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_KEY_ID_COMPUTED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_KEY_ID_COMPUTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_ESCROW_CSR"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_ESCROW_CSR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_ESCROW_KEY"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_ESCROW_KEY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_NON_ESCROW_CSR"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_NON_ESCROW_CSR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_PUK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEED_PUK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEW_ESCROW_CERT_ISSUED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEW_ESCROW_CERT_ISSUED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEXT_CSR_TO_ISSUE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NEXT_CSR_TO_ISSUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NO_STORED_PUK_AVAIL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_NO_STORED_PUK_AVAIL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_OWNER_IDENTIFIED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_OWNER_IDENTIFIED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PERSIST_CSRS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PERSIST_CSRS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PIN_CONTINUE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PIN_CONTINUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PIN_MISSING"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PIN_MISSING"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_CREATED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_CREATED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_PARAMETERS_SET"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_PARAMETERS_SET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_PASSWORD_ENCRYPTED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_PASSWORD_ENCRYPTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_TO_INSTALL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PKCS12_TO_INSTALL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_POLICY_INPUT_REQUIRED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_POLICY_INPUT_REQUIRED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREPARE_CERT_INST"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREPARE_CERT_INST"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREPARE_CSRS_TO_PROCESS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREPARE_CSRS_TO_PROCESS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREPARE_ESCROW_CERT_INSTALLATION"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREPARE_ESCROW_CERT_INSTALLATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREP_LOOP_NEED_CSR"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREP_LOOP_NEED_CSR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREREQS_AVAILABLE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PREREQS_AVAILABLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PRE_ISSUANCE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PRE_ISSUANCE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PRE_SUCCESS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PRE_SUCCESS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PRIVATE_KEY_RENAMED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PRIVATE_KEY_RENAMED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PUK_TO_INSTALL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_PUK_TO_INSTALL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_QUEUE_CERTS_TO_RECOVER"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_QUEUE_CERTS_TO_RECOVER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_QUEUE_CSR_TO_ISSUE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_QUEUE_CSR_TO_ISSUE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_START_ACTIONS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_START_ACTIONS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_SUCCESS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_SUCCESS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_USER_INFO_REGISTERED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_USER_INFO_REGISTERED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_WHICH_CERT_TO_INSTALL"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_WHICH_CERT_TO_INSTALL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_X509_PREPARED"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PERSONALIZATION_V4_X509_PREPARED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_ATTEMPTED_RT_NOTIFY"
-msgstr "Initializing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_ATTEMPTED_RT_NOTIFY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CAN_FETCH_PUK"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CAN_FETCH_PUK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CAN_WRITE_PIN"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CAN_WRITE_PIN"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CHECK_FOR_ACT_HASHES"
-msgstr "CRL published"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CHECK_FOR_ACT_HASHES"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CHECK_MAX_PIN_ITERAT"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CHECK_MAX_PIN_ITERAT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CHECK_TOKEN_OWNER"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_CHECK_TOKEN_OWNER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_FAILURE"
-msgstr "Initial state of the LDAP publishing workflow"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_FAILURE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_GET_AUTH1_LDAP"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_GET_AUTH1_LDAP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_GET_AUTH2_LDAP"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_GET_AUTH2_LDAP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_HAVE_CODES"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_HAVE_CODES"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_HAVE_TOKEN_ID"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_HAVE_TOKEN_ID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_HAVE_TOKEN_OWNER"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_HAVE_TOKEN_OWNER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_INITIAL"
-msgstr "Initial state of the LDAP publishing workflow"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_INITIAL"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_PEND_ACT_CODE"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_PEND_ACT_CODE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_PEND_PIN_CHANGE"
-msgstr "Initializing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_PEND_PIN_CHANGE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_RESET_LDAP_ERR"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_RESET_LDAP_ERR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_SUCCESS"
-msgstr "Smartcard personalization"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_SUCCESS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_URL_SET"
-msgstr "Initial state of the LDAP publishing workflow"
+msgstr "I18N_OPENXPKI_WF_STATE_SMARTCARD_PIN_UNBLOCK_URL_SET"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_STATE_VICE_INITIAL"
-msgstr "Initializing ..."
+msgstr "I18N_OPENXPKI_WF_STATE_VICE_INITIAL"
 
 msgid "I18N_OPENXPKI_WF_STATE_WAITING_FOR_START"
 msgstr "Waiting to start"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_ISSUANCE"
-msgstr "CRL Issuance"
+msgstr "Issue certificate"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_LDAP_PUBLISHING"
 msgstr "Publish a certificate using LDAP"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_PUBLISHING"
-msgstr "Publish a certificate using LDAP"
+msgstr "Publish certificate"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_RENEWAL_REQUEST"
-msgstr "Certificate Revocation Request (CRR)"
+msgstr "Certificate renewal request"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOCATION_REQUEST"
 msgstr "Certificate Revocation Request (CRR)"
@@ -6078,13 +5267,11 @@ msgstr "Certificate Revocation Request (CRR)"
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOCATION_REQUEST_OFFLINE_CA"
 msgstr "Offline part of a Certificate Revocation Request (CRR)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOCATION_REQUEST_V2"
-msgstr "Certificate Revocation Request (CRR)"
+msgstr "Certificate revocation request (v2)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOKE"
-msgstr "Certificate Issuance"
+msgstr "Revoke certificate"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST"
 msgstr "Certificate Signing Request (CSR)"
@@ -6092,13 +5279,11 @@ msgstr "Certificate Signing Request (CSR)"
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_OFFLINE_CA"
 msgstr "Offline part of a Certificate Signing Request (CSR)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_V2"
-msgstr "Certificate Signing Request (CSR)"
+msgstr "Certificate Signing Request (v2)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CERT_EXPORT"
-msgstr "Export"
+msgstr "Export certificate"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CHANGE_METADATA"
 msgstr "Change a certificate's metadata"
@@ -6108,23 +5293,21 @@ msgstr "CRL Issuance"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CYCLE_SUB"
-msgstr "CRL Issuance"
+msgstr "I18N_OPENXPKI_WF_TYPE_CYCLE_SUB"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CYCLE_SUB2"
-msgstr "CRL Issuance"
+msgstr "I18N_OPENXPKI_WF_TYPE_CYCLE_SUB2"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CYCLE_TOP"
-msgstr "SCEP Certificate Signing Request"
+msgstr "I18N_OPENXPKI_WF_TYPE_CYCLE_TOP"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_ENROLLMENT"
-msgstr "SCEP Certificate Signing Request"
+msgstr "Workflow: Enrollnment"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_PASSWORD_SAFE"
-msgstr "CRL Issuance"
+msgstr "Workflow: Password safe"
 
 msgid "I18N_OPENXPKI_WF_TYPE_SCEP_REQUEST"
 msgstr "SCEP Certificate Signing Request"
@@ -6132,155 +5315,145 @@ msgstr "SCEP Certificate Signing Request"
 msgid "I18N_OPENXPKI_WF_TYPE_SMARTCARD_PERSONALIZATION"
 msgstr "Smartcard personalization"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_SMARTCARD_PERSONALIZATION_V4"
-msgstr "Smartcard personalization"
+msgstr "Workflow: Smartcard personalization (v4)"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_SMARTCARD_PIN_UNBLOCK"
-msgstr "CRL Issuance"
+msgstr "Workflow: Smartcard PIN unblock"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_SMARTCARD_PUK_UPLOAD"
-msgstr "CRL Issuance"
+msgstr "Workflow: Smartcard PUK upload"
 
-#, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_TESTING"
-msgstr "CRL Issuance"
+msgstr "Workflow: testing"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_VICE_CREDITS"
-msgstr "SCEP Certificate Signing Request"
+msgstr "I18N_OPENXPKI_WF_TYPE_VICE_CREDITS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_BULK"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_VAL_BULK"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_CERTPROFILE"
-msgstr "Change certificate profile"
+msgstr "I18N_OPENXPKI_WF_VAL_CERTPROFILE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_CERTROLE"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_VAL_CERTROLE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_CERTSUBJECTALTNAMEPARTS"
-msgstr "Change subject alternative name"
+msgstr "I18N_OPENXPKI_WF_VAL_CERTSUBJECTALTNAMEPARTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_CERTSUBJECTPARTS"
-msgstr "Subject"
+msgstr "I18N_OPENXPKI_WF_VAL_CERTSUBJECTPARTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_CERT_IDENTIFIER_EXISTS"
-msgstr "Reject CSR"
+msgstr "I18N_OPENXPKI_WF_VAL_CERT_IDENTIFIER_EXISTS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_CREATOR"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_VAL_CREATOR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_HASREQUIREDFIELD"
-msgstr "Approve CSR"
+msgstr "I18N_OPENXPKI_WF_VAL_HASREQUIREDFIELD"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_INVALIDITYTIME"
-msgstr "Change CRR invalidity time"
+msgstr "I18N_OPENXPKI_WF_VAL_INVALIDITYTIME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_KEYLENGTH"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_WF_VAL_KEYLENGTH"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_KEYREUSE"
-msgstr "Key usage"
+msgstr "I18N_OPENXPKI_WF_VAL_KEYREUSE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_PASSWORDQUALITY"
-msgstr "Issue a certificate revocation list (CRL)"
+msgstr "I18N_OPENXPKI_WF_VAL_PASSWORDQUALITY"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_PKCS10"
-msgstr "Export CSR"
+msgstr "I18N_OPENXPKI_WF_VAL_PKCS10"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_REASONCODE"
-msgstr "Adding missing node"
+msgstr "I18N_OPENXPKI_WF_VAL_REASONCODE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_RELATIVEDATE"
-msgstr "Last update"
+msgstr "I18N_OPENXPKI_WF_VAL_RELATIVEDATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_SPKAC"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_WF_VAL_SPKAC"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_UNUSEDID"
-msgstr "failed"
+msgstr "I18N_OPENXPKI_WF_VAL_UNUSEDID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_VALIDAPPROVALSIGNATURECRR"
-msgstr "Approve CRR"
+msgstr "I18N_OPENXPKI_WF_VAL_VALIDAPPROVALSIGNATURECRR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_VALIDAPPROVALSIGNATURECSR"
-msgstr "Approve CSR"
+msgstr "I18N_OPENXPKI_WF_VAL_VALIDAPPROVALSIGNATURECSR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VAL_VALIDITYTIME"
-msgstr "Validity"
+msgstr "I18N_OPENXPKI_WF_VAL_VALIDITYTIME"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_VICE_PERSIST_CREDITS"
-msgstr "Persist CSR"
+msgstr "I18N_OPENXPKI_WF_VICE_PERSIST_CREDITS"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_ACTIVITY_INVALID_ARGUMENT"
-msgstr "This workflow failed finally and can not be restarted"
+msgstr "I18N_OPENXPKI_WORKFLOW_ACTIVITY_INVALID_ARGUMENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_ACTIVITY_MISSING_CONTEXT_PARAMETER"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_WORKFLOW_ACTIVITY_MISSING_CONTEXT_PARAMETER"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_ACTIVITY_TOOLS_PAUSE_MISSING_DURATION"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_WORKFLOW_ACTIVITY_TOOLS_PAUSE_MISSING_DURATION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_ACTIVITY_TOOLS_PAUSE_NO_REASON"
-msgstr ""
-"The workflow is missing some required fields (__FIELDS__) for the next "
-"action."
+msgstr "I18N_OPENXPKI_WORKFLOW_ACTIVITY_TOOLS_PAUSE_NO_REASON"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_FACTORY_INSTANCE_METHOD_NOT_SUPPORTED"
-msgstr "The SPKAC string is empty."
+msgstr "I18N_OPENXPKI_WORKFLOW_FACTORY_INSTANCE_METHOD_NOT_SUPPORTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_HANDLER_GET_FACTORY_UNKNOWN_VERSION_REQUESTED"
-msgstr "Workflow parent"
+msgstr "I18N_OPENXPKI_WORKFLOW_HANDLER_GET_FACTORY_UNKNOWN_VERSION_REQUESTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_METADATA_WRONG_SYSTEM_ID"
-msgstr "This workflow is paused and will be continued by the watchdog"
+msgstr "I18N_OPENXPKI_WORKFLOW_METADATA_WRONG_SYSTEM_ID"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_RUNTIME_EXCEPTION"
-msgstr "Workflow parent"
+msgstr "I18N_OPENXPKI_WORKFLOW_RUNTIME_EXCEPTION"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_UNKNOWN_PROC_STATE"
-msgstr "Workflow parent"
+msgstr "I18N_OPENXPKI_WORKFLOW_UNKNOWN_PROC_STATE"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WORKFLOW_UNKNOWN_PROC_STATE_ACTION"
-msgstr "Workflow parent"
+msgstr "I18N_OPENXPKI_WORKFLOW_UNKNOWN_PROC_STATE_ACTION"
 
 msgid "I18N_OPENXPKI_WRITE_FILE_ALREADY_EXISTS"
 msgstr "There is already a file with the given file name"
@@ -6296,69 +5469,67 @@ msgstr "Could not open the file"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_GET_SUPER_ENTRY_PATH_NOT_FOUND"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_GET_SUPER_ENTRY_PATH_NOT_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_GET_XPATH_COUNT_MISSING_ELEMENT"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_GET_XPATH_COUNT_MISSING_ELEMENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_GET_XPATH_COUNT_NOTHING_FOUND"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_GET_XPATH_COUNT_NOTHING_FOUND"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_GET_XPATH_HASHREF_MISSING_ELEMENT"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_GET_XPATH_HASHREF_MISSING_ELEMENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_GET_XPATH_HASHREF_RESULT_NOT_A_HASHREF"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_GET_XPATH_HASHREF_RESULT_NOT_A_HASHREF"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_GET_XPATH_MISSING_CONTENT"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_GET_XPATH_MISSING_CONTENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_GET_XPATH_MISSING_ELEMENT"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_GET_XPATH_MISSING_ELEMENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_INIT_XML_ERROR"
-msgstr "Valid"
+msgstr "I18N_OPENXPKI_XML_CACHE_INIT_XML_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_INIT_XML_SCHEMA_ERROR"
-msgstr ""
-"An internal error occured while reading data from the CA server. Error: "
-"__ERROR__"
+msgstr "I18N_OPENXPKI_XML_CACHE_INIT_XML_SCHEMA_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_PARSE_SUPER_ELEMENT_ENTRY_ERROR_PARSING_PATH_ELEMENT"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_PARSE_SUPER_ELEMENT_ENTRY_ERROR_PARSING_PATH_ELEMENT"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_PERFORM_SUPER_RESOLUTION_TOO_MANY_INTERATIONS_POSSIBLE_SUPER_LOOP"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_XML_CACHE_PERFORM_SUPER_RESOLUTION_TOO_MANY_INTERATIONS_POSSIBLE_SUPER_LOOP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_PERFORM_XINCLUDE_POSSIBLE_LOOP_DETECTED"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_XML_CACHE_PERFORM_XINCLUDE_POSSIBLE_LOOP_DETECTED"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_PERFORM_XINCLUDE_XML_ERROR"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_XML_CACHE_PERFORM_XINCLUDE_XML_ERROR"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_RELATIVE_TOO_MANY_LEVELS_UP"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_XML_CACHE_RELATIVE_TOO_MANY_LEVELS_UP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_REPLACE_SUPER_LEVEL_TOO_DEEP_POSSIBLE_SUPER_LOOP"
-msgstr "Sleep"
+msgstr "I18N_OPENXPKI_XML_CACHE_REPLACE_SUPER_LEVEL_TOO_DEEP_POSSIBLE_SUPER_LOOP"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_UNEXPECTED_DATA_STRUCTURE"
-msgstr "testuser"
+msgstr "I18N_OPENXPKI_XML_CACHE_UNEXPECTED_DATA_STRUCTURE"
 
 #, fuzzy
 #~ msgid "I18N_OPENXPKI_ACTION_CHANGEMETA_LOAD_FORM"

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_crl.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_crl.pm
@@ -37,7 +37,8 @@ sub get_command
     if ($self->{OUT} ne 'DER' && $self->{OUT} ne 'TXT' && $self->{OUT} ne 'PEM')
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CRL_WRONG_OUTPUT_FORMAT");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_CRL_WRONG_OUTPUT_FORMAT",
+            params => { OUTPUT_FORMAT => $self->{OUT} } );
     }
 
     ## build the command

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_key.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_key.pm
@@ -50,7 +50,8 @@ sub get_command
         $self->{ENC_ALG} ne "des")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_ENC_ALG");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{ENC_ALG} );
     }
     if (not exists $self->{PASSWD})
     {
@@ -67,7 +68,8 @@ sub get_command
         $self->{IN} ne "PKCS8")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_INPUT_FORMAT");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_INPUT_FORMAT",
+            params => { INPUT_FORMAT => $self->{IN} });
     }
     if (not exists $self->{OUT})
     {
@@ -82,7 +84,8 @@ sub get_command
         $self->{OUT} ne "OPENSSL_EC")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_OUTPUT_FORMAT");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_OUTPUT_FORMAT",
+            params => { OUTPUT_FORMAT => $self->{OUT} });
     }
     if (not exists $self->{DATA})
     {

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_pkcs10.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_pkcs10.pm
@@ -46,7 +46,8 @@ sub get_command
     if ($self->{OUT} ne "DER" && $self->{OUT} ne "TXT" && $self->{OUT} ne 'PEM')
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_PKCS10_WRONG_OUTPUT_FORMAT");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_PKCS10_WRONG_OUTPUT_FORMAT",
+            params => { OUTPUT_FORMAT => $self->{OUT} });
     }
 
     ## build the command

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/DSA.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/DSA.pm
@@ -34,7 +34,8 @@ sub verify_params
         $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} ne "des")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} });
     }
 
     if ($self->{PARENT_REF}->{PARAMETERS}->{KEY_LENGTH} != 512 and
@@ -44,7 +45,8 @@ sub verify_params
         $self->{PARENT_REF}->{PARAMETERS}->{KEY_LENGTH} != 4096)
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_KEY_LENGTH");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_KEY_LENGTH",
+            params => { KEY_LENGTH => $self->{PARENT_REF}->{PARAMETERS}->{KEY_LENGTH} });
     }
 
     return 1;

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/EC.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/EC.pm
@@ -34,7 +34,8 @@ sub verify_params
         $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} ne "des")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} });
     }
 
     if ($self->{PARENT_REF}->{PARAMETERS}->{CURVE_NAME} !~ /^(secp|prime|sect|c2pnb|c2tnb)[1-9][0-9]{2}?[krvw][1-3]$/i and
@@ -44,7 +45,8 @@ sub verify_params
         $self->{PARENT_REF}->{PARAMETERS}->{CURVE_NAME} !~ /^wap-wsg-idm-ecid-wtls[0-9]*$/)
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_EC_CURVE_NAME");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_EC_CURVE_NAME",
+            params => { EC_CURVE_NAME => $self->{PARENT_REF}->{PARAMETERS}->{CURVE_NAME} });
     }
 
     return 1;

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST2001.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST2001.pm
@@ -33,7 +33,8 @@ sub verify_params
          and $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} ne "des" )
     {
         OpenXPKI::Exception->throw( message =>
-            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG");
+            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} });
     }
 
     return 1;

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST2001CP.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST2001CP.pm
@@ -33,7 +33,8 @@ sub verify_params
          and $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} ne "des" )
     {
         OpenXPKI::Exception->throw( message =>
-            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG");
+            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} });
     }
 
     return 1;

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST94.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST94.pm
@@ -33,7 +33,8 @@ sub verify_params
          and $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} ne "des" )
     {
         OpenXPKI::Exception->throw( message =>
-            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG");
+            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} });
     }
 
     return 1;

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST94CP.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/GOST94CP.pm
@@ -33,7 +33,8 @@ sub verify_params
          and $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} ne "des" )
     {
         OpenXPKI::Exception->throw( message =>
-            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG");
+            "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} });
     }
 
     return 1;

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/RSA.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_key/RSA.pm
@@ -34,7 +34,8 @@ sub verify_params
         $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} ne "des")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{PARENT_REF}->{PARAMETERS}->{ENC_ALG} });
     }
 
     if ($self->{PARENT_REF}->{PARAMETERS}->{KEY_LENGTH} != 512 and
@@ -44,7 +45,8 @@ sub verify_params
         $self->{PARENT_REF}->{PARAMETERS}->{KEY_LENGTH} != 4096)
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_KEY_LENGTH");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_KEY_WRONG_KEY_LENGTH",
+            params => { KEY_LENGTH => $self->{PARENT_REF}->{PARAMETERS}->{KEY_LENGTH} });
     }
 
     return 1;

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_pkcs12.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/create_pkcs12.pm
@@ -65,7 +65,8 @@ sub get_command
         $self->{ENC_ALG} ne "des")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_RSA_WRONG_ENC_ALG");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CREATE_RSA_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{ENC_ALG} });
     }
 
     if (exists $self->{CSP}) {

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/issue_crl.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/issue_crl.pm
@@ -57,7 +57,8 @@ sub get_command
     my $key_store = $self->{ENGINE}->get_key_store();
     if ($key_store ne 'ENGINE' && not -e $self->{KEYFILE}) {
             OpenXPKI::Exception->throw (
-                message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CRL_KEYFILE_DOES_NOT_EXIST");        
+                message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_ISSUE_CRL_KEYFILE_DOES_NOT_EXIST",
+                params => { KEYFILE => $self->{KEYFILE} });
     }
 
     ## prepare data

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/pkcs7_encrypt.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/pkcs7_encrypt.pm
@@ -70,7 +70,8 @@ sub get_command
         $self->{ENC_ALG} ne "des")
     {
         OpenXPKI::Exception->throw (
-            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_ENCRYPT_WRONG_ENC_ALG");
+            message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_PKCS7_ENCRYPT_WRONG_ENC_ALG",
+            params => { ENC_ALG => $self->{ENC_ALG} });
     }
 
     ## prepare data

--- a/core/server/OpenXPKI/Server/API/Token.pm
+++ b/core/server/OpenXPKI/Server/API/Token.pm
@@ -89,13 +89,14 @@ sub get_token_alias_by_type {
 
     ##! 32: "Lookup group for type $keys->{TYPE}"
     $keys->{GROUP} = CTX('config')->get("crypto.type.".$keys->{TYPE});
-    delete $keys->{TYPE};
 
    if (not $keys->{GROUP}) {
         OpenXPKI::Exception->throw (
             message => 'I18N_OPENXPKI_API_TOKEN_ALIAS_BY_TYPE_NO_GROUP_FOUND',
+            params => { TYPE => $keys->{TYPE} }
         );
     }
+    delete $keys->{TYPE};
 
     ##! 32: " Found keys " . Dumper ($keys)
 


### PR DESCRIPTION
Translated about a half of existing `I18N_` tags. What's left are mostly error messages (I beiieve only few regular UI strings left to be translated). Some tags are suggested to be removed (comments). The untranslated messages have tag set as the translaed msg and are marked fuzzy.
