### PR TITLE
Change binmode to utf8 on sockets

### DIFF
--- a/core/server/OpenXPKI/Transport/Simple.pm
+++ b/core/server/OpenXPKI/Transport/Simple.pm
@@ -31,7 +31,10 @@ sub new
     my $keys = shift;
     $self->{INFILE}  = $keys->{INFILE}  if (exists $keys->{INFILE});
     $self->{OUTFILE} = $keys->{OUTFILE} if (exists $keys->{OUTFILE});
-    $self->{SOCKET}  = $keys->{SOCKET}  if (exists $keys->{SOCKET});
+    if(exists $keys->{SOCKET}) {
+        $self->{SOCKET}  = $keys->{SOCKET}; 
+        binmode($self->{SOCKET},':utf8');
+    }
 
     ##! 1: "transport layer successfully initialized"
     return $self;


### PR DESCRIPTION
I found such a hack necessary in order to allow UTF-8 accents in UI. Without the fix, if I enter UTF-8 string, such as "Paweł" in web UI (e.g. in `realname` field for CSR) and try to send it to server I get:

```
send_receive_msg() failed in OpenXPKI::Client::send_receive_service_msg() (error: talk() failed in OpenXPKI::Client::send_service_msg() (error: write() failed in OpenXPKI::Client::talk() (error: __send() failed in OpenXPKI::Transport::Simple::write() (error: Wide character in send at /usr/lib/perl5/OpenXPKI/Transport/Simple.pm line 215. ))))
```

If I already have an UTF-8 data in MySQL DB, then web UI also reports failures and I'm unable to perform operations on data containing utf8 strings, for example:

```
failed in OpenXPKI::Client::send_receive_service_msg() (error: I18N_OPENXPKI_TRANSPORT_SIMPLE_CLIENT_READ_CLOSED_CONNECTION at /usr/lib/perl5/OpenXPKI/Client.pm line 148. , state: can_send)
```

Note, that this is a kind of hack, I wasn't sure where is the appropriate place for the fix. I don't know, if it doesn't alter stuff such as SCEP and communication with external services. Please verify, if you can.

Thanks.

