### PR TITLE
Workflow translations + fixes for travis CI (reworked)

### DIFF
--- a/core/i18n/en_GB/openxpki.po
+++ b/core/i18n/en_GB/openxpki.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: OpenXPKI 0.9\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2004-09-08 14:02+0200\n"
-"PO-Revision-Date: 2014-09-04 14:05+0100\n"
+"PO-Revision-Date: 2014-09-05 13:16+0100\n"
 "Last-Translator: Paweł Tomulik <ptomulik@meil.pw.edu.pl>\n"
 "Language-Team: OpenXPKI developers list <openxpki-devel@lists.sourceforge."
 "net>\n"
@@ -506,7 +506,8 @@ msgstr ""
 
 msgid "I18N_OPENXPKI_CRYPTO_CSR_GET_INFO_HASH_EVAL_OF_DUMP_FAILED"
 msgstr ""
-"Dumper failed (error: __EVAL_ERROR) in OpenXPKI::Crypto::CSR::get_info_hash()"
+"Dumper failed (error: __EVAL_ERROR__) in OpenXPKI::Crypto::CSR::"
+"get_info_hash()"
 
 # This should be probably removed. It appears only in a commented-out block of code.
 msgid "I18N_OPENXPKI_CRYPTO_CSR_INIT_MISSING_SUBJECT"
@@ -522,8 +523,7 @@ msgid "I18N_OPENXPKI_CRYPTO_CSR_NEW_WRONG_TYPE"
 msgstr "Wrong CSR type (__TYPE__) in call to OpenXPKI::Crypto::CSR::new()"
 
 msgid "I18N_OPENXPKI_CRYPTO_OBJECT_GET_PARSED_NO_VALUE"
-msgstr ""
-"Missing value (PARSED) in call to OpenXPKI::Crypto::Object::get_parsed()"
+msgstr "Found no value for __NAME__ in OpenXPKI::Crypto::Object::get_parsed()"
 
 msgid "I18N_OPENXPKI_CRYPTO_OBJECT_SET_HEADER_ATTRIBUTE_REINIT_FAILED"
 msgstr ""
@@ -5259,7 +5259,7 @@ msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_PUBLISHING"
 msgstr "Publish certificate"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_RENEWAL_REQUEST"
-msgstr "Certificate renewal request"
+msgstr "Certificate Renewal Request"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOCATION_REQUEST"
 msgstr "Certificate Revocation Request (CRR)"
@@ -5268,7 +5268,7 @@ msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOCATION_REQUEST_OFFLINE_CA"
 msgstr "Offline part of a Certificate Revocation Request (CRR)"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOCATION_REQUEST_V2"
-msgstr "Certificate revocation request (v2)"
+msgstr "Certificate Revocation Request (CRR v2)"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_REVOKE"
 msgstr "Revoke certificate"
@@ -5280,16 +5280,16 @@ msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_OFFLINE_CA"
 msgstr "Offline part of a Certificate Signing Request (CSR)"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_V2"
-msgstr "Certificate Signing Request (v2)"
+msgstr "Certificate Signing Request (CSR v2)"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CERT_EXPORT"
 msgstr "Export certificate"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CHANGE_METADATA"
-msgstr "Change a certificate's metadata"
+msgstr "Change Certificate Metadata"
 
 msgid "I18N_OPENXPKI_WF_TYPE_CRL_ISSUANCE"
-msgstr "CRL Issuance"
+msgstr "Certificate Revocation List (CRL) Issuance"
 
 #, fuzzy
 msgid "I18N_OPENXPKI_WF_TYPE_CYCLE_SUB"
@@ -5530,6 +5530,318 @@ msgstr "I18N_OPENXPKI_XML_CACHE_REPLACE_SUPER_LEVEL_TOO_DEEP_POSSIBLE_SUPER_LOOP
 #, fuzzy
 msgid "I18N_OPENXPKI_XML_CACHE_UNEXPECTED_DATA_STRUCTURE"
 msgstr "I18N_OPENXPKI_XML_CACHE_UNEXPECTED_DATA_STRUCTURE"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_SUCCESS_LABEL"
+msgstr "SUCCESS"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_FAILURE_LABEL"
+msgstr "FAILURE"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_PENDING_LABEL"
+msgstr "PENDING"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_APPROVAL_LABEL"
+msgstr "APPROVAL"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_TITLE"
+msgstr "Workflow Search"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_DESCRIPTION"
+msgstr "You can search for workflows here."
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SUBMIT_LABEL"
+msgstr "Search now"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_WORKFLOW_ID_LABEL"
+msgstr "Workflow Id"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SEARCH_BY_ID_TITLE"
+msgstr "Get workflow info by known workflow id"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SEARCH_DATABASE_TITLE"
+msgstr "Search the database"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_TYPE_LABEL"
+msgstr "Type"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_LABEL"
+msgstr "State"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_CREATOR_LABEL"
+msgstr "Creator"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_TITLE"
+msgstr "Workflow history"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_DESCRIPTION"
+msgstr "Use workflow history for audit or troubleshooting"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_EXEC_TIME_LABEL"
+msgstr "Execution time"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_STATE_LABEL"
+msgstr "State"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_ACTION_LABEL"
+msgstr "Action"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_DESCRIPTION_LABEL"
+msgstr "Description"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_USER_LABEL"
+msgstr "User"
+
+#, fuzzy
+msgid "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_LOAD_DATA"
+msgstr "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_LOAD_DATA"
+
+#, fuzzy
+msgid "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_LOAD_FORM"
+msgstr "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_LOAD_FORM"
+
+#, fuzzy
+msgid "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_PERSIST"
+msgstr "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_PERSIST"
+
+#, fuzzy
+msgid "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_TERMINATE"
+msgstr "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_TERMINATE"
+
+#, fuzzy
+msgid "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_UPDATE_CONTEXT"
+msgstr "I18N_OPENXPKI_WF_ACTION_CHANGEMETA_UPDATE_CONTEXT"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CREATE_CSR"
+msgstr "Create CSR"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CRR_EDIT_REQUEST"
+msgstr "Edit Request"
+
+#, fuzzy
+msgid "I18N_OPENXPKI_WF_ACTION_CRR_FLAG_PENDING_NOTIFICATION_SEND"
+msgstr "I18N_OPENXPKI_WF_ACTION_CRR_FLAG_PENDING_NOTIFICATION_SEND"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CRR_SEND_PENDING_NOTIFICATION"
+msgstr "Send Pending Notification"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CRR_UPDATE_REQUEST"
+msgstr "Update Request"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_APPROVE_CSR"
+msgstr "Approve CSR"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_ASK_CLIENT_PASSWORD"
+msgstr "Ask Client Password"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_CANCEL_APPROVALS"
+msgstr "Cancel Approvals"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_CLEANUP_KEY_PASSWORD"
+msgstr "Cleanup Key Password"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_EDIT_CERT_INFO"
+msgstr "Edit Certificate Info"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_EDIT_SAN"
+msgstr "Edit Alternative Name"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_EDIT_SUBJECT"
+msgstr "Edit Subject"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_EDIT_VALIDITY"
+msgstr "Edit Validity"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_EVAL_ELIGIBILITY"
+msgstr "Evaluate Eligibility"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_FLAG_PENDING_NOTIFICATION_SEND"
+msgstr "Send Pending Notification"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_LOAD_KEY_PASSWORD"
+msgstr "Load Key Password"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_MOVE_KEY_TO_DP"
+msgstr "Move Key to DP"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_NOTIFY_APPROVAL"
+msgstr "Notify of Approval"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_NOTIFY_ISSUED"
+msgstr "Notify of Issuance"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_NOTIFY_REJECTED"
+msgstr "Notify of Rejection"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_PERSIST_CSR"
+msgstr "Persist CSR"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_PERSIST_KEY_PASSWORD"
+msgstr "Persist Key Password"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_PERSIST_METADATA"
+msgstr "Persist Metadata"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_PROVIDE_SERVER_KEY_PARAMS"
+msgstr "Provide Key Parameters"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_PUBLISH_CERTIFICATE"
+msgstr "Publish Certificate"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_PUT_REQUEST_ON_HOLD"
+msgstr "Put Request on Hold"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_REJECT_REQUEST"
+msgstr "Reject Request"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_RELEASE_ON_HOLD"
+msgstr "Release on Hold"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_RENAME_PRIVATE_KEY"
+msgstr "Rename Private Key"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_RENDER_SUBJECT"
+msgstr "Render Subject"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_RETYPE_SERVER_PASSWORD"
+msgstr "Retype Server Password"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_SELECT_PROFILE"
+msgstr "Select Profile"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_SEND_PENDING_NOTIFICATION"
+msgstr "Send Notification of Pending"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_SUBMIT"
+msgstr "Submit CSR"
+
+msgid "I18N_OPENXPKI_WF_ACTION_CSR_UPLOAD_PKCS10"
+msgstr "Upload PKCS10"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_ADD_AUTHENTICATION"
+msgstr "Add Authentication"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_ALLOW_RETRY"
+msgstr "Allow Retry"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_CALC_APPROVALS"
+msgstr "Calculate Approvals"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_CLEAR_APPROVALS"
+msgstr "Clear Approvals"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_CONTINUE_ISSUANCE"
+msgstr "Continue Issuance"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_DENY_AUTHENTICATION"
+msgstr "Deny Authentication"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_DISAPPROVE"
+msgstr "Disapprove"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_EVAL_CHALLENGE"
+msgstr "Evaluate Challenge"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_EVAL_ELIGIBILITY"
+msgstr "Evaluate Eligibility"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_EVAL_SIGNER_TRUST"
+msgstr "Evaluate Signer Trust"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_EXTRACT_CSR"
+msgstr "Extract CSR"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_FAIL"
+msgstr "Fail"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_FETCH_GROUP_POLICY"
+msgstr "Fetch Group Policy"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_FORK_PUBLISH"
+msgstr "Fork Publish"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_GET_CERT_PROFILE"
+msgstr "Get Certificate Profile"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_INITIALIZE"
+msgstr "Initialize"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_INVALIDATE_CHALLENGE_PASS"
+msgstr "Invalidate Challenge Password"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_ISSUE_CERT"
+msgstr "Issue Certificate"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_LOAD_RECENT_CERTIFICATE"
+msgstr "Load Recent Certificate"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_MODIFY_METADATA"
+msgstr "Modify Metadata"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_NEXT_CERT_TO_REVOKE"
+msgstr "Next Certificate to Revoke"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_NOTIFY_CERT_ISSUED"
+msgstr "Notify of Issuance"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_NOTIFY_PENDING_APPROVAL"
+msgstr "Notify of Pending Approval"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_NULL1"
+msgstr "NULL1"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_NULL2"
+msgstr "NULL2"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_PERSIST_CERT_METADATA"
+msgstr "Persist Metadata"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_PERSIST_CSR"
+msgstr "Persist CSR"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_REVOKE_CERT"
+msgstr "Revoke Certificate"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_REVOKE_CERT_AFTER_REPLACE"
+msgstr "Revoke After Replace"
+
+msgid "I18N_OPENXPKI_WF_ACTION_ENROLL_REVOKE_EXISTING_CERTS"
+msgstr "Revoke Existing Certificates"
+
+msgid "I18N_OPENXPKI_WF_ACTION_GLOBAL_NULL"
+msgstr "NULL"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_ID_LABEL"
+msgstr "Workflow Id"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_PROC_STATE_LABEL"
+msgstr "Run State"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_OPEN_WORKFLOW_LABEL"
+msgstr "Open Workflow"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_HISTORY_LABEL"
+msgstr "Workflow History"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_RESULTS_TITLE"
+msgstr "Workflow Search - Results"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_RESULTS_DESCRIPTION"
+msgstr "Results of your search:"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SERIAL_LABEL"
+msgstr "Serial"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_SEARCH_UPDATED_LABEL"
+msgstr "Updated"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_TYPE_LABEL"
+msgstr "Type"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_STATE_LABEL"
+msgstr "State"
+
+msgid "I18N_OPENXPKI_UI_WORKFLOW_WAKE_UP_LABEL"
+msgstr "Wake Up"
 
 #, fuzzy
 #~ msgid "I18N_OPENXPKI_ACTION_CHANGEMETA_LOAD_FORM"
@@ -8589,10 +8901,6 @@ msgstr "I18N_OPENXPKI_XML_CACHE_UNEXPECTED_DATA_STRUCTURE"
 
 #~ msgid "I18N_OPENXPKI_WF_ACTION_CONTINUE_ISSUANCE"
 #~ msgstr "Continue with issuance"
-
-#, fuzzy
-#~ msgid "I18N_OPENXPKI_WF_ACTION_CREATE_CSR"
-#~ msgstr "Reject CSR"
 
 #, fuzzy
 #~ msgid "I18N_OPENXPKI_WF_ACTION_CREATE_SERVER_CSR"

--- a/core/server/OpenXPKI/Client/UI/Workflow.pm
+++ b/core/server/OpenXPKI/Client/UI/Workflow.pm
@@ -7,6 +7,7 @@ package OpenXPKI::Client::UI::Workflow;
 use Moose;
 use Data::Dumper;
 use OpenXPKI::i18n qw( i18nGettext );
+use OpenXPKI::Client::UI::Workflow::Translations qw(i18n_action);
 
 extends 'OpenXPKI::Client::UI::Result';
 
@@ -108,45 +109,60 @@ sub init_search {
     my $args = shift;
 
     $self->_page({
-        label => 'Workflow Search',
-        description => 'You can search for workflows here.',
+        label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_TITLE'),
+        description => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_DESCRIPTION'),
     });
 
     my $workflows = $self->send_command( 'list_workflow_titles' );
     return $self unless(defined $workflows);
 
-    # TODO Sorting / I18
     my @wf_names = keys %{$workflows};
-    @wf_names = sort @wf_names;
-
-    my @wfl_list = map { $_ = {'value' => $_, 'label' => $workflows->{$_}->{label}} } @wf_names ;
+    my @wfl_list = map { $_ = {'value' => $_, 'label' => i18nGettext($workflows->{$_}->{label})} } @wf_names ;
+    @wfl_list = sort { lc($a->{'label'}) cmp lc($b->{'label'}) } @wfl_list;
 
     my @states = (
-        { label => 'SUCCESS', value => 'SUCCESS' },
-        { label => 'FAILURE', value => 'FAILURE' },
-        { label => 'PENDING', value => 'PENDING' },
-        { label => 'APPROVAL', value => 'APPROVAL' },
+        { label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_SUCCESS_LABEL'), value => 'SUCCESS' },
+        { label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_FAILURE_LABEL'), value => 'FAILURE' },
+        { label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_PENDING_LABEL'), value => 'PENDING' },
+        { label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_APPROVAL_LABEL'), value => 'APPROVAL' },
     );
+    @states = sort { lc($a->{'label'}) cmp lc($b->{'label'}) } @states;
 
     $self->_result()->{main} = [
         {   type => 'form',
             action => 'workflow!load',
             content => {
-                title => 'Get workflow info by known workflow id',
-                submit_label => 'search now',
+                title => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SEARCH_BY_ID_TITLE'),
+                submit_label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SUBMIT_LABEL'),
                 fields => [
-                    { name => 'wf_id', label => 'Workflow Id', type => 'text' },
+                    { name => 'wf_id', label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_WORKFLOW_ID_LABEL'), type => 'text' },
                 ]
         }},
         {   type => 'form',
             action => 'workflow!search',
             content => {
-                title => 'Search the database',
-                submit_label => 'search now',
+                title => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SEARCH_DATABASE_TITLE'),
+                submit_label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SUBMIT_LABEL'),
                 fields => [
-                    { name => 'wf_type', label => 'Type', type => 'select', is_optional => 1,  options => \@wfl_list  },
-                    { name => 'wf_state', label => 'State', type => 'select', is_optional => 1, editable => 0, prompt => '', options => \@states },
-                    { name => 'wf_creator', label => 'Creator', type => 'text', is_optional => 1 },
+                    { name => 'wf_type',
+                      label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_TYPE_LABEL'), 
+                      type => 'select',
+                      is_optional => 1,
+                      options => \@wfl_list 
+                    },
+                    { name => 'wf_state',
+                      label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_STATE_LABEL'), #'State',
+                      type => 'select',
+                      is_optional => 1,
+                      editable => 0,
+                      prompt => '',
+                      options => \@states
+                    },
+                    { name => 'wf_creator',
+                      label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_CREATOR_LABEL'), # 'Creator',
+                      type => 'text',
+                      is_optional => 1
+                    },
                 ]
         }}
     ];
@@ -162,8 +178,8 @@ sub init_history {
     my $id = $self->param('wf_id');
 
     $self->_page({
-        label => 'Workflow History',
-        description => '',
+        label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_TITLE'),
+        description => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_DESCRIPTION'),
     });
 
     my $workflow_history = $self->send_command( 'get_workflow_history', { ID => $id } );
@@ -175,9 +191,9 @@ sub init_history {
     foreach my $item (@{$workflow_history}) {
         push @result, [
             $item->{'WORKFLOW_HISTORY_DATE'},
-            $item->{'WORKFLOW_STATE'},
-            $item->{'WORKFLOW_ACTION'},
-            $item->{'WORKFLOW_DESCRIPTION'},
+            i18nGettext($item->{'WORKFLOW_STATE'}),
+            i18nGettext(i18n_action($item->{'WORKFLOW_ACTION'})),
+            i18nGettext($item->{'WORKFLOW_DESCRIPTION'}),
             $item->{'WORKFLOW_USER'}
         ]
     }
@@ -190,11 +206,11 @@ sub init_history {
         processing_type => 'all',
         content => {
             columns => [
-                { sTitle => "execution time" }, #, format => 'datetime'},
-                { sTitle => "state" },
-                { sTitle => "action"},
-                { sTitle => "description"},
-                { sTitle => "user"},
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_EXEC_TIME_LABEL') }, #, format => 'datetime'},
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_STATE_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_ACTION_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_DESCRIPTION_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_USER_LABEL') },
             ],
             data => \@result
         }
@@ -518,8 +534,8 @@ sub action_search {
     $self->logger()->debug( "search result: " . Dumper $search_result);
 
     $self->_page({
-        label => 'Workflow Search - Results',
-        description => 'Results of your search:',
+        label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_RESULTS_TITLE'),
+        description => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_RESULTS_DESCRIPTION'),
     });
 
     my $i = 1;
@@ -528,11 +544,12 @@ sub action_search {
         push @result, [
             $item->{'WORKFLOW.WORKFLOW_SERIAL'},
             $item->{'WORKFLOW.WORKFLOW_LAST_UPDATE'},
-            $item->{'WORKFLOW.WORKFLOW_TYPE'},
-            $item->{'WORKFLOW.WORKFLOW_STATE'},
-            $item->{'WORKFLOW.WORKFLOW_PROC_STATE'},
+            i18nGettext($item->{'WORKFLOW.WORKFLOW_TYPE'}),
+            i18nGettext($item->{'WORKFLOW.WORKFLOW_STATE'}),
+            i18nGettext($item->{'WORKFLOW.WORKFLOW_PROC_STATE'}),
             $item->{'WORKFLOW.WORKFLOW_WAKEUP_AT'},
-        ]
+            $item->{'WORKFLOW.WORKFLOW_SERIAL'},
+        ];
     }
 
     $self->logger()->trace( "dumper result: " . Dumper @result);
@@ -545,17 +562,18 @@ sub action_search {
             header => 'Grid-Headline',
             actions => [{
                 path => 'workflow!load!wf_id!{serial}!view!result',
-                label => 'Open Workflow',
+                label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_OPEN_WORKFLOW_LABEL'),
                 icon => 'view',
                 target => 'tab',
             }],
             columns => [
-                { sTitle => "serial" },
-                { sTitle => "updated" },
-                { sTitle => "type"},
-                { sTitle => "state"},
-                { sTitle => "procstate"},
-                { sTitle => "wake up", format => 'timestamp' },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_SERIAL_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_SEARCH_UPDATED_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_TYPE_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_STATE_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_PROC_STATE_LABEL') },
+                { sTitle => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_WAKE_UP_LABEL'), format => 'timestamp' },
+                { sTitle => 'serial', bVisible => 0 },
             ],
             data => \@result
         }
@@ -819,13 +837,13 @@ sub __render_from_workflow {
         if ($args->{VIEW} && $args->{VIEW} eq 'result' && $wf_info->{WORKFLOW}->{STATE} !~ /(SUCCESS|FAILURE)/) {
             @buttons = ({
                 'action' => 'redirect!workflow!load!wf_id!'.$wf_info->{WORKFLOW}->{ID},
-                'label' => 'open workflow',
+                'label' => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_OPEN_WORKFLOW_LABEL'), #'open workflow',
             });
         }
 
         push @buttons, {
             'action' => 'redirect!workflow!history!wf_id!'.$wf_info->{WORKFLOW}->{ID},
-            'label' => 'workflow history',
+            'label' => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_HISTORY_LABEL'),
         };
 
         $self->_result()->{right} = [{
@@ -834,9 +852,9 @@ sub __render_from_workflow {
                 label => '',
                 description => '',
                 data => [
-                    { label => 'Workflow Id', value => $wf_info->{WORKFLOW}->{ID} },
-                    { label => 'Workflow State', value => $wf_info->{WORKFLOW}->{STATE} },
-                    { label => 'Run State', value => $wf_info->{WORKFLOW}->{PROC_STATE} }
+                    { label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_ID_LABEL'), value => $wf_info->{WORKFLOW}->{ID} },
+                    { label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_STATE_LABEL'), value => $wf_info->{WORKFLOW}->{STATE} },
+                    { label => i18nGettext('I18N_OPENXPKI_UI_WORKFLOW_PROC_STATE_LABEL'), value => $wf_info->{WORKFLOW}->{PROC_STATE} }
                 ],
                 buttons => \@buttons,
         }}];
@@ -865,7 +883,7 @@ sub __get_action_buttons {
     foreach my $wf_action (keys %{$wf_info->{ACTIVITY}}) {
        my $wf_action_info = $wf_info->{ACTIVITY}->{$wf_action};
        push @buttons, {
-            label => i18nGettext($wf_action_info->{LABEL} || $wf_action),
+            label => i18nGettext(i18n_action($wf_action_info->{LABEL} || $wf_action)),
             action => sprintf 'workflow!select!wf_action!%s!wf_id!%01d', $wf_action, $wf_info->{WORKFLOW}->{ID},
         };
     }
@@ -903,7 +921,7 @@ sub __delegate_call {
     <state name="DATA_LOADED">
         <description>I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_LOADED</description>
         <action name="changemeta_update" resulting_state="DATA_UPDATE"/>
-        <action name="changemeta_persist" resulting_state="SUCCESS"/>
+        <action name="I18N_OPENXPKI_WF_ACTION_CHANGEMETA_PERSIST" resulting_state="SUCCESS"/>
     </state>
     ...
     <action name="changemeta_update"
@@ -911,7 +929,7 @@ sub __delegate_call {
         description="I18N_OPENXPKI_ACTION_UPDATE_METADATA">
         <field name="metadata_update" />
     </action>
-    <action name="changemeta_persist"
+    <action name="I18N_OPENXPKI_WF_ACTION_CHANGEMETA_PERSIST"
         class="OpenXPKI::Server::Workflow::Activity::PersistData">
     </action>
 
@@ -919,7 +937,7 @@ When reached first, a page with the text from the description tag and two
 buttons will appear. The update button has I18N_OPENXPKI_ACTION_UPDATE_METADATA
 as label an after pushing it, a form with one text field will be rendered.
 The persist button has no description and will have the action name
-changemeta_persist as label. As it has no input fields, the workflow will go
+I18N_OPENXPKI_WF_ACTION_CHANGEMETA_PERSIST as label. As it has no input fields, the workflow will go
 to the next state without further ui interaction.
 
 =head2 State with custom rendering
@@ -937,7 +955,7 @@ reached, the render_current_data method is called.
     <state name="DATA_LOADED">
         <description>I18N_OPENXPKI_WF_STATE_CHANGE_METADATA_LOADED</description>
         <action name="changemeta_update" resulting_state="DATA_UPDATE"/>
-        <action name="changemeta_persist" resulting_state="SUCCESS"/>
+        <action name="I18N_OPENXPKI_WF_ACTION_CHANGEMETA_PERSIST" resulting_state="SUCCESS"/>
     </state>
 
     <action name="changemeta_update"

--- a/core/server/OpenXPKI/Client/UI/Workflow/Translations.pm
+++ b/core/server/OpenXPKI/Client/UI/Workflow/Translations.pm
@@ -1,0 +1,93 @@
+# OpenXPKI::Client::UI::Workflow::Translations
+#
+# This module enables translations for the stuff retrieved from old *.xml
+# configuration. I suggest to keep and use this module until the *.xml is
+# used by any people, but no longer.
+
+
+package OpenXPKI::Client::UI::Workflow::Translations;
+require Exporter;
+@ISA = qw(Exporter);
+@EXPORT_OK = qw(&i18n_action);
+
+sub i18n_action {
+    my $name = shift;
+    my $actions = {
+        changemeta_load_data => 'I18N_OPENXPKI_WF_ACTION_CHANGEMETA_LOAD_DATA',
+        changemeta_load_form => 'I18N_OPENXPKI_WF_ACTION_CHANGEMETA_LOAD_FORM',
+        changemeta_persist => 'I18N_OPENXPKI_WF_ACTION_CHANGEMETA_PERSIST',
+        changemeta_terminate => 'I18N_OPENXPKI_WF_ACTION_CHANGEMETA_TERMINATE',
+        changemeta_update_context => 'I18N_OPENXPKI_WF_ACTION_CHANGEMETA_UPDATE_CONTEXT',
+        create_csr => 'I18N_OPENXPKI_WF_ACTION_CREATE_CSR',
+        crr_edit_request => 'I18N_OPENXPKI_WF_ACTION_CRR_EDIT_REQUEST',
+        crr_flag_pending_notification_send => 'I18N_OPENXPKI_WF_ACTION_CRR_FLAG_PENDING_NOTIFICATION_SEND',
+        crr_send_pending_notification => 'I18N_OPENXPKI_WF_ACTION_CRR_SEND_PENDING_NOTIFICATION',
+        crr_update_request => 'I18N_OPENXPKI_WF_ACTION_CRR_UPDATE_REQUEST',
+        csr_approve_csr => 'I18N_OPENXPKI_WF_ACTION_CSR_APPROVE_CSR',
+        csr_ask_client_password => 'I18N_OPENXPKI_WF_ACTION_CSR_ASK_CLIENT_PASSWORD',
+        csr_cancel_approvals => 'I18N_OPENXPKI_WF_ACTION_CSR_CANCEL_APPROVALS',
+        csr_cleanup_key_password => 'I18N_OPENXPKI_WF_ACTION_CSR_CLEANUP_KEY_PASSWORD',
+        csr_edit_cert_info => 'I18N_OPENXPKI_WF_ACTION_CSR_EDIT_CERT_INFO',
+        csr_edit_san => 'I18N_OPENXPKI_WF_ACTION_CSR_EDIT_SAN',
+        csr_edit_subject => 'I18N_OPENXPKI_WF_ACTION_CSR_EDIT_SUBJECT',
+        csr_edit_validity => 'I18N_OPENXPKI_WF_ACTION_CSR_EDIT_VALIDITY',
+        csr_eval_eligibility => 'I18N_OPENXPKI_WF_ACTION_CSR_EVAL_ELIGIBILITY',
+        csr_flag_pending_notification_send => 'I18N_OPENXPKI_WF_ACTION_CSR_FLAG_PENDING_NOTIFICATION_SEND',
+        csr_generate_key => 'I18N_OPENXPKI_WF_ACTION_CSR_GENERATE_KEY',
+        csr_generate_key_client => 'I18N_OPENXPKI_WF_ACTION_CSR_GENERATE_KEY_CLIENT',
+        csr_generate_pkcs10 => 'I18N_OPENXPKI_WF_ACTION_CSR_GENERATE_PKCS10',
+        csr_load_key_password => 'I18N_OPENXPKI_WF_ACTION_CSR_LOAD_KEY_PASSWORD',
+        csr_move_key_to_dp => 'I18N_OPENXPKI_WF_ACTION_CSR_MOVE_KEY_TO_DP',
+        csr_notify_approval => 'I18N_OPENXPKI_WF_ACTION_CSR_NOTIFY_APPROVAL',
+        csr_notify_issued => 'I18N_OPENXPKI_WF_ACTION_CSR_NOTIFY_ISSUED',
+        csr_notify_rejected => 'I18N_OPENXPKI_WF_ACTION_CSR_NOTIFY_REJECTED',
+        csr_persist_csr => 'I18N_OPENXPKI_WF_ACTION_CSR_PERSIST_CSR',
+        csr_persist_key_password => 'I18N_OPENXPKI_WF_ACTION_CSR_PERSIST_KEY_PASSWORD',
+        csr_persist_metadata => 'I18N_OPENXPKI_WF_ACTION_CSR_PERSIST_METADATA',
+        csr_provide_server_key_params => 'I18N_OPENXPKI_WF_ACTION_CSR_PROVIDE_SERVER_KEY_PARAMS',
+        csr_publish_certificate => 'I18N_OPENXPKI_WF_ACTION_CSR_PUBLISH_CERTIFICATE',
+        csr_put_request_on_hold => 'I18N_OPENXPKI_WF_ACTION_CSR_PUT_REQUEST_ON_HOLD',
+        csr_reject_request => 'I18N_OPENXPKI_WF_ACTION_CSR_REJECT_REQUEST',
+        csr_release_on_hold => 'I18N_OPENXPKI_WF_ACTION_CSR_RELEASE_ON_HOLD',
+        csr_rename_private_key => 'I18N_OPENXPKI_WF_ACTION_CSR_RENAME_PRIVATE_KEY',
+        csr_render_subject => 'I18N_OPENXPKI_WF_ACTION_CSR_RENDER_SUBJECT',
+        csr_retype_server_password => 'I18N_OPENXPKI_WF_ACTION_CSR_RETYPE_SERVER_PASSWORD',
+        csr_select_profile => 'I18N_OPENXPKI_WF_ACTION_CSR_SELECT_PROFILE',
+        csr_send_pending_notification => 'I18N_OPENXPKI_WF_ACTION_CSR_SEND_PENDING_NOTIFICATION',
+        csr_submit => 'I18N_OPENXPKI_WF_ACTION_CSR_SUBMIT',
+        csr_upload_pkcs10 => 'I18N_OPENXPKI_WF_ACTION_CSR_UPLOAD_PKCS10',
+        enroll_add_authentication => 'I18N_OPENXPKI_WF_ACTION_ENROLL_ADD_AUTHENTICATION',
+        enroll_allow_retry => 'I18N_OPENXPKI_WF_ACTION_ENROLL_ALLOW_RETRY',
+        enroll_calc_approvals => 'I18N_OPENXPKI_WF_ACTION_ENROLL_CALC_APPROVALS',
+        enroll_clear_approvals => 'I18N_OPENXPKI_WF_ACTION_ENROLL_CLEAR_APPROVALS',
+        enroll_continue_issuance => 'I18N_OPENXPKI_WF_ACTION_ENROLL_CONTINUE_ISSUANCE',
+        enroll_deny_authentication => 'I18N_OPENXPKI_WF_ACTION_ENROLL_DENY_AUTHENTICATION',
+        enroll_disapprove => 'I18N_OPENXPKI_WF_ACTION_ENROLL_DISAPPROVE',
+        enroll_eval_challenge => 'I18N_OPENXPKI_WF_ACTION_ENROLL_EVAL_CHALLENGE',
+        enroll_eval_eligibility => 'I18N_OPENXPKI_WF_ACTION_ENROLL_EVAL_ELIGIBILITY',
+        enroll_eval_signer_trust => 'I18N_OPENXPKI_WF_ACTION_ENROLL_EVAL_SIGNER_TRUST',
+        enroll_extract_csr => 'I18N_OPENXPKI_WF_ACTION_ENROLL_EXTRACT_CSR',
+        enroll_fail => 'I18N_OPENXPKI_WF_ACTION_ENROLL_FAIL',
+        enroll_fetch_group_policy => 'I18N_OPENXPKI_WF_ACTION_ENROLL_FETCH_GROUP_POLICY',
+        enroll_fork_publish => 'I18N_OPENXPKI_WF_ACTION_ENROLL_FORK_PUBLISH',
+        enroll_get_cert_profile => 'I18N_OPENXPKI_WF_ACTION_ENROLL_GET_CERT_PROFILE',
+        enroll_initialize => 'I18N_OPENXPKI_WF_ACTION_ENROLL_INITIALIZE',
+        enroll_invalidate_challenge_pass => 'I18N_OPENXPKI_WF_ACTION_ENROLL_INVALIDATE_CHALLENGE_PASS',
+        enroll_issue_cert => 'I18N_OPENXPKI_WF_ACTION_ENROLL_ISSUE_CERT',
+        enroll_load_recent_certificate => 'I18N_OPENXPKI_WF_ACTION_ENROLL_LOAD_RECENT_CERTIFICATE',
+        enroll_modify_metadata => 'I18N_OPENXPKI_WF_ACTION_ENROLL_MODIFY_METADATA',
+        enroll_next_cert_to_revoke => 'I18N_OPENXPKI_WF_ACTION_ENROLL_NEXT_CERT_TO_REVOKE',
+        enroll_notify_cert_issued => 'I18N_OPENXPKI_WF_ACTION_ENROLL_NOTIFY_CERT_ISSUED',
+        enroll_notify_pending_approval => 'I18N_OPENXPKI_WF_ACTION_ENROLL_NOTIFY_PENDING_APPROVAL',
+        enroll_null1 => 'I18N_OPENXPKI_WF_ACTION_ENROLL_NULL1',
+        enroll_null2 => 'I18N_OPENXPKI_WF_ACTION_ENROLL_NULL2',
+        enroll_persist_cert_metadata => 'I18N_OPENXPKI_WF_ACTION_ENROLL_PERSIST_CERT_METADATA',
+        enroll_persist_csr => 'I18N_OPENXPKI_WF_ACTION_ENROLL_PERSIST_CSR',
+        enroll_revoke_cert => 'I18N_OPENXPKI_WF_ACTION_ENROLL_REVOKE_CERT',
+        enroll_revoke_cert_after_replace => 'I18N_OPENXPKI_WF_ACTION_ENROLL_REVOKE_CERT_AFTER_REPLACE',
+        enroll_revoke_existing_certs => 'I18N_OPENXPKI_WF_ACTION_ENROLL_REVOKE_EXISTING_CERTS',
+        generate_key => 'I18N_OPENXPKI_WF_ACTION_GENERATE_KEY',
+        global_null => 'I18N_OPENXPKI_WF_ACTION_GLOBAL_NULL',
+    };
+    return $actions->{$name} || $name;
+}

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_key.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Command/convert_key.pm
@@ -51,7 +51,7 @@ sub get_command
     {
         OpenXPKI::Exception->throw (
             message => "I18N_OPENXPKI_CRYPTO_OPENSSL_COMMAND_CONVERT_KEY_WRONG_ENC_ALG",
-            params => { ENC_ALG => $self->{ENC_ALG} );
+            params => { ENC_ALG => $self->{ENC_ALG} });
     }
     if (not exists $self->{PASSWD})
     {

--- a/core/server/OpenXPKI/Server/Workflow/Activity.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity.pm
@@ -52,22 +52,22 @@ sub init {
         $_map->{$name} = $params->{$key};
         ##! 8: 'Found param ' . $name . ' - value : ' . $params->{$key}
 
-=cut disabled-by-oli
-
-        if ($val =~ /^\$(\S+)/) {
-            # copy from context
-            $_map->{$name} = ['ctx', $1];
-
-        } else { # }if ($val =~ /^\&(\S+)/) {
-            # TT parser
-            $_map->{$name} = ['tt', $val ];
-        #} else {
-        #
-        #    # static value, add to plain params hash
-        #    $params_merged->{$name} = $val;
-        }
-
-=cut disabled-by-oli
+##=cut disabled-by-oli
+##
+##        if ($val =~ /^\$(\S+)/) {
+##            # copy from context
+##            $_map->{$name} = ['ctx', $1];
+##
+##        } else { # }if ($val =~ /^\&(\S+)/) {
+##            # TT parser
+##            $_map->{$name} = ['tt', $val ];
+##        #} else {
+##        #
+##        #    # static value, add to plain params hash
+##        #    $params_merged->{$name} = $val;
+##        }
+##
+##=cut disabled-by-oli
 
     }
 

--- a/core/server/OpenXPKI/Server/Workflow/Activity/Tools/CancelApprovals.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity/Tools/CancelApprovals.pm
@@ -29,19 +29,19 @@ sub execute
     FACILITY => ['audit','application']
     );
 
-=cut disabled-by-oli
-
-    my $bulk = $context->param('bulk');
-    if (! $bulk) {
-        # only notify if this is not part of a bulk request - otherwise
-        # the user would get a huge number of tickets
-        CTX('notification')->notify({
-            MESSAGE  => 'csr_approvals_canceled',
-            WORKFLOW => $workflow,
-        });
-    }
-
-=cut disabled-by-oli
+##=cut disabled-by-oli
+##
+##    my $bulk = $context->param('bulk');
+##    if (! $bulk) {
+##        # only notify if this is not part of a bulk request - otherwise
+##        # the user would get a huge number of tickets
+##        CTX('notification')->notify({
+##            MESSAGE  => 'csr_approvals_canceled',
+##            WORKFLOW => $workflow,
+##        });
+##    }
+##
+##=cut disabled-by-oli
 
     return 1;
 }

--- a/core/server/t/15_dn/4.t
+++ b/core/server/t/15_dn/4.t
@@ -8,6 +8,7 @@
 use strict;
 use warnings;
 use utf8;
+use open ':std', ':encoding(utf8)';
 binmode STDERR, ":utf8";
 use Test::More;
 use OpenXPKI::DN;


### PR DESCRIPTION
This PR enchances i18n for workflows. It enables translations for most widgets appearing on workflow search, workflow search result, workflow edition, and workflow history pages. Currently translated items include static labels/titles as well as action names rendered to jS grids and action buttons. Mapping actions' `short_name` to `I18N_OPENXPKI_WF_ACTION_XXXX` is delegated to separate perl module `OpenXPKI::Client::UI::Workflow::Translations`. That way we still have same *.xml workflow configs and same contens in DB but get translated strings on the UI.
