### PR TITLE
Fixes to SMTP notifications

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Authors:
 * Alexey Rudenko
 * Gabriel Sailer
 * Shota Okuhara
+* Paweł Tomulik

--- a/config/openxpki/notification/email/csr_created_raop.html
+++ b/config/openxpki/notification/email/csr_created_raop.html
@@ -1,0 +1,26 @@
+<html><body>
+
+<img src="cid:banner" />
+
+<p>
+Dear Operator,
+</p>
+
+<p>We have received a new certification request with the following data:<br/><br/>
+
+Requestor: [% requestor %]<br/>
+Subject: [% cert_subject %]<br/>
+[% FOREACH san = cert_subject_alt_name  -%]
+Subject alternative name: [% san.0 %]: [% san.1 %]</br>
+[% END -%]
+</p>
+<p>
+For this request, a new workflow has been created on the CA system
+with ID [% meta_wf_id %].
+</p>
+<p><i>
+Regards,<br/>
+  PKI Team</i>
+</p>
+<img src="cid:footer" />
+</body></html>

--- a/config/openxpki/notification/email/scep_approval_pending_raop.html
+++ b/config/openxpki/notification/email/scep_approval_pending_raop.html
@@ -1,0 +1,27 @@
+<html><body>
+
+<img src="cid:banner" />
+
+<p>
+Dear Operator,
+</p>
+
+<p>We have received a new certification request via SCEP with the following
+data:<br/><br/>
+
+Subject: [% cert_subject %]<br/>
+[% FOREACH san = cert_subject_alt_name  -%]
+Subject alternative name: [% san.0 %]: [% san.1 %]<br/>
+[% END -%]
+</p>
+<p>
+For this request, a new workflow has been created on the CA system
+with ID [% meta_wf_id %].
+</p>
+<p><i>
+Regards,<br/>
+  PKI Team</i>
+</p>
+
+<img src="cid:footer" />
+</body></html>

--- a/config/openxpki/notification/email/scep_approval_rejected.html
+++ b/config/openxpki/notification/email/scep_approval_rejected.html
@@ -1,15 +1,21 @@
 <html><body>
 
+<img src="cid:banner" />
+
 <p>
 Dear Customer,
 </p>
-<p>
-We have to inform you that your SCEP certificate request for <b>[% cert_subject %]</b> has been rejected.
+
+<p>We have to inform you that your SCEP certificate request for<br/>
+  [% cert_subject %]<br/>
+has been rejected.</p>
+
+<p>If you have any questions on this matter, please contact us.</p>
+
+<p><i>
+Regards,<br/>
+  PKI Team</i>
 </p>
 
-<p>
-If you have any questions on this matter, please contact us.
-</p>
-
-<p><i>Regards,<br/>PKI Team</i></p>
+<img src="cid:footer" />
 </body></html>

--- a/config/openxpki/notification/email/scpu_notify_authcontact.html
+++ b/config/openxpki/notification/email/scpu_notify_authcontact.html
@@ -1,0 +1,49 @@
+<html><body>
+
+<img src="cid:banner" />
+
+[% IF to == data.auth1_mail %]
+    [% SET name = data.auth1_name %]
+    [% SET mail = data.auth1_mail %]
+[% ELSE %]
+    [% SET name = data.auth2_name %]
+    [% SET mail = data.auth2_mail %]
+[% END %]
+<p>
+Dear [% name %],
+</p>
+
+<p>
+A request to reset the PIN of the Smartcard belonging to<br/><br/>
+
+    [% data.requestor_name %] <[% data.requestor_mail %]><br/><br/>
+
+has been made.
+</p>
+
+<p>
+That person has specified you as one of the authorizing persons and requests
+that you authorize the transaction. To assist this person, please do the
+following:<br/><br/>
+
+<ol>
+  <li>Fetch your activation code at the following address:<br/>
+
+    [% meta_baseurl %]/service/reset_token/unblock_pin.html?WF_ID=[% workflow_id %]
+  </li>
+  <li>Give the activation code to the Smartcard owner so he or she can complete the
+    transaction.</li>
+</ol>
+<p>
+If you do not know this person or otherwise suspect abuse or fraud, do not
+forward the activation code to anyone. Instead, please contact your
+security officer immediately to report the incident.
+</p>
+
+<p>
+Note: The request tracking ticket for this notification will be automatically
+closed.
+</p>
+
+<img src="cid:footer" />
+</body></html>

--- a/config/openxpki/notification/email/scpu_notify_user.html
+++ b/config/openxpki/notification/email/scpu_notify_user.html
@@ -1,0 +1,20 @@
+<p>Dear [% data.requestor_name %],</p>
+
+<p>
+The unblocking codes to reset your SmartCard PIN have been send to the following persons:<br/><br/>
+
+ [% data.auth1_name %] ([% data.auth1_mail %])<br/>
+ [% data.auth2_name %] ([% data.auth2_mail %])<br/>
+</p>
+
+<p>Plese contact them to get your unblocking codes.</p>
+
+<p>If you have any questions on this matter, please contact us.</p>
+
+<p><i>
+Regards,<br/>
+  PKI Team</i>
+</p>
+
+<img src="cid:footer" />
+</body></html>

--- a/core/server/OpenXPKI/Server/Notification/SMTP/SSL.pm
+++ b/core/server/OpenXPKI/Server/Notification/SMTP/SSL.pm
@@ -1,0 +1,42 @@
+## OpenXPKI::Server::Notification::SMTP
+## SMTP::SSL Notifier
+##
+
+=head1 Name
+
+OpenXPKI::Server::Notification::SMTP::SSL - Notification via SMTP using SSL
+
+=head1 Description
+
+This class implements a notifier that sends out notification as
+plain plain text message using Net::SMTP::SSL. The templates for the mails
+are read from the filesystem.
+
+=head1 Configuration
+
+Same as for OpenXPKI::Server::Notification::SMTP
+
+=cut
+
+package OpenXPKI::Server::Notification::SMTP::SSL;
+
+use strict;
+use warnings;
+use English;
+
+use Data::Dumper;
+
+use Net::SMTP::SSL;
+
+use Moose;
+
+extends 'OpenXPKI::Server::Notification::SMTP';
+
+sub _new_smtp {
+  my $self = shift;
+  return Net::SMTP::SSL->new( @_ );
+}
+
+1;
+
+__END__


### PR DESCRIPTION
This PR contains three things:
- added missing HTML templates under `/etc/openxpki/notification/email/`; I was unable to run notifications with default templates installed by deb package,
- added authentication step in the module - I've observed that SMTP connections were made anonymously, even if the `username` and `password` were provided in config; according to [Net::SMTP documentation](http://search.cpan.org/dist/libnet/Net/SMTP.pm) the `Net::SMTP::new()` does not understand `User` nor `Password`,
- implemented module `OpenXPKI::Server::Notification::SMTP::SSL` to allow SMTP over SSL based on [Net::SMTP::SSL](http://search.cpan.org/~cwest/Net-SMTP-SSL-1.01/lib/Net/SMTP/SSL.pm), on Debian this requires `libnet-smtp-ssl-perl` package; this package is available in repos for Debian `wheezy`; I wasn't able to make `Net::SMTP::TLS` to work and `Net::SMTPS` (which looks to be also good alternative) is not available as Debian package on `wheezy` so I didn't give it try.

With theese fixes I was finally able to successfuly enable notifications on my system (which is restricted to SMTS).
