### PR TITLE
enable utf8 logs

### DIFF
--- a/config/openxpki/log.conf
+++ b/config/openxpki/log.conf
@@ -52,30 +52,36 @@ log4perl.appender.Logfile.filename = /var/openxpki/openxpki.log
 log4perl.appender.Logfile.layout   = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.Logfile.layout.ConversionPattern = %d %c.%p:%P %m%n
 log4perl.appender.Logfile.syswrite  = 1
+log4perl.appender.Logfile.utf8 = 1
 
 log4perl.appender.WorkflowLog          = Log::Log4perl::Appender::File
 log4perl.appender.WorkflowLog.filename = /var/openxpki/workflow.log
 log4perl.appender.WorkflowLog.layout   = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.WorkflowLog.layout.ConversionPattern = %d %c.%p:%P %m%n
 log4perl.appender.WorkflowLog.syswrite  = 1
+log4perl.appender.WorkflowLog.utf8 = 1
 
 log4perl.appender.Connector          = Log::Log4perl::Appender::File
 log4perl.appender.Connector.filename = /var/openxpki/connector.log
 log4perl.appender.Connector.layout   = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.Connector.layout.ConversionPattern = %d %c.%p:%P %m%n
 log4perl.appender.Connector.syswrite  = 1
+log4perl.appender.Connector.utf8 = 1
 
 log4perl.appender.CatchAll          = Log::Log4perl::Appender::File
 log4perl.appender.CatchAll.filename = /var/openxpki/catchall.log
 log4perl.appender.CatchAll.layout   = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.CatchAll.layout.ConversionPattern = %d %c.%p:%P %m%n
 log4perl.appender.CatchAll.syswrite  = 1
+log4perl.appender.CatchAll.utf8 = 1
 
 log4perl.appender.Syslog           = Log::Dispatch::Syslog
 log4perl.appender.Syslog.facility  = local7
 log4perl.appender.Syslog.layout    = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.Syslog.layout.ConversionPattern = %d %c.%p:%P %m
+log4perl.appender.Syslog.utf8 = 1
 
 log4perl.appender.DBI              = OpenXPKI::Server::Log::Appender::DBI
 log4perl.appender.DBI.layout       = Log::Log4perl::Layout::NoopLayout
 log4perl.appender.DBI.warp_message = 0
+log4perl.appender.DBI.utf8 = 1

--- a/config/openxpki/scep/log.conf
+++ b/config/openxpki/scep/log.conf
@@ -9,3 +9,4 @@ log4perl.appender.Logfile.filename = /var/openxpki/scep.log
 log4perl.appender.Logfile.layout   = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.Logfile.layout.ConversionPattern = %d %p:%P %m%n
 log4perl.appender.Logfile.syswrite  = 1
+log4perl.appender.Logfile.utf8 = 1

--- a/config/openxpki/webui/log.conf
+++ b/config/openxpki/webui/log.conf
@@ -5,3 +5,4 @@ log4perl.appender.Logfile.filename = /var/openxpki/webui.log
 log4perl.appender.Logfile.layout   = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.Logfile.layout.ConversionPattern = %m%n
 log4perl.appender.Logfile.syswrite  = 1
+log4perl.appender.Logfile.utf8 = 1


### PR DESCRIPTION
Without this I was unable to approve CSRs with utf-8 in metadata:

```
root@ca:/etc/openxpki# grep Wide /var/openxpki/catchall.log
2014/09/07 06:26:25 Workflow.ERROR:16601 Caught exception from action: Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
2014/09/07 06:26:25 openxpki.workflow.ERROR:16601 [OpenXPKI::Server::API::Workflow (/usr/lib/perl5/OpenXPKI/Server/API/Workflow.pm:1009); ra(RA Operator)@e791] Error executing workflow activity 'csr_persist_metadata' on workflow id 3583 (type I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_V2): I18N_OPENXPKI_SERVER_WORKFLOW_ERROR_ON_EXECUTE; __ERROR__ => Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
2014/09/07 06:41:42 Workflow.ERROR:16663 Caught exception from action: Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
2014/09/07 06:41:42 openxpki.workflow.ERROR:16663 [OpenXPKI::Server::API::Workflow (/usr/lib/perl5/OpenXPKI/Server/API/Workflow.pm:1009); ra(RA Operator)@e791] Error executing workflow activity 'csr_persist_metadata' on workflow id 3583 (type I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_V2): I18N_OPENXPKI_SERVER_WORKFLOW_ERROR_ON_EXECUTE; __ERROR__ => Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
2014/09/07 06:42:47 Workflow.ERROR:16708 Caught exception from action: Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
2014/09/07 06:42:47 openxpki.workflow.ERROR:16708 [OpenXPKI::Server::API::Workflow (/usr/lib/perl5/OpenXPKI/Server/API/Workflow.pm:1009); ra(RA Operator)@d089] Error executing workflow activity 'csr_persist_metadata' on workflow id 3583 (type I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_V2): I18N_OPENXPKI_SERVER_WORKFLOW_ERROR_ON_EXECUTE; __ERROR__ => Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
2014/09/07 06:47:29 Workflow.ERROR:16782 Caught exception from action: Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
2014/09/07 06:47:29 openxpki.workflow.ERROR:16782 [OpenXPKI::Server::API::Workflow (/usr/lib/perl5/OpenXPKI/Server/API/Workflow.pm:1009); ra(RA Operator)@cf2f] Error executing workflow activity 'csr_persist_metadata' on workflow id 3583 (type I18N_OPENXPKI_WF_TYPE_CERTIFICATE_SIGNING_REQUEST_V2): I18N_OPENXPKI_SERVER_WORKFLOW_ERROR_ON_EXECUTE; __ERROR__ => Wide character in syswrite at /usr/share/perl5/Log/Log4perl/Appender/File.pm line 242.
```

The error was also printed in UI and it couldn't persist data because, in fact, it couldn't print some debug messages to logs.