### PR TITLE
Fix/missing import

### DIFF
--- a/core/server/OpenXPKI/Server/Workflow/Activity/Tools/Disconnect.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity/Tools/Disconnect.pm
@@ -6,6 +6,7 @@ package OpenXPKI::Server::Workflow::Activity::Tools::Disconnect;
 
 use strict;
 use base qw( OpenXPKI::Server::Workflow::Activity );
+use OpenXPKI::Server::Context qw( CTX );
 
 
 sub init {


### PR DESCRIPTION
CTX is used in `execute` method but it should be imported first. I had errors without this patch.
