### PR TITLE
Revert shebang from using /usr/bin/env for issue #156

### DIFF
--- a/clients/perl/OpenXPKI-Client-Enrollment/script/enroller
+++ b/clients/perl/OpenXPKI-Client-Enrollment/script/enroller
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/clients/perl/OpenXPKI-Client-Enrollment/script/sscep-wrapper
+++ b/clients/perl/OpenXPKI-Client-Enrollment/script/sscep-wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/clients/perl/OpenXPKI-Client-Enrollment/t/mock-scep-server
+++ b/clients/perl/OpenXPKI-Client-Enrollment/t/mock-scep-server
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 use Mojolicious::Lite;
 
 use lib ('lib', '../../../qatest/lib');

--- a/clients/perl/OpenXPKI-Client-Enrollment/t/sscep-mock
+++ b/clients/perl/OpenXPKI-Client-Enrollment/t/sscep-mock
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/i18n/Makefile
+++ b/core/i18n/Makefile
@@ -8,6 +8,7 @@ PO_SOURCES   = $(LANGS:%=%/openxpki.po)
 MO_TRANSLATIONS = $(LANGS:%=%/$(MO_FILE))
 POT_SOURCES  = ../server ../../config 
 VERSION_FILE    = ./VERSION
+PACKAGE      ?= openxpki-i18n
 
 #---- variable settings above, rules below ----
 
@@ -88,18 +89,18 @@ VERSION=$(shell cat $(VERSION_FILE))
 
 #dist:	VERSION=`$(VERGEN) --format version`
 dist: readversion
-	if (test -d openxpki-i18n-$(VERSION)) ; then \
-		rm -rf openxpki-i18n-$(VERSION)/ ; \
+	if (test -d $(PACKAGE)-$(VERSION)) ; then \
+		rm -rf $(PACKAGE)-$(VERSION)/ ; \
 	fi
-	mkdir openxpki-i18n-$(VERSION)
+	mkdir $(PACKAGE)-$(VERSION)
 	tar -c -p -f - \
 		--exclude "*.svn" \
-		--exclude "openxpki-i18n-*" \
+		--exclude "$(PACKAGE)-*" \
 		--exclude "*.1" \
 		--exclude "*~" \
 		. | \
-		tar -C openxpki-i18n-$(VERSION)/ -x -f -
-	tar cf openxpki-i18n-$(VERSION).tar openxpki-i18n-$(VERSION)
-	gzip --best --force openxpki-i18n-$(VERSION).tar
-	rm -rf openxpki-i18n-$(VERSION)/
+		tar -C $(PACKAGE)-$(VERSION)/ -x -f -
+	tar cf $(PACKAGE)-$(VERSION).tar $(PACKAGE)-$(VERSION)
+	gzip --best --force $(PACKAGE)-$(VERSION).tar
+	rm -rf $(PACKAGE)-$(VERSION)/
 

--- a/core/i18n/build-pot.pl
+++ b/core/i18n/build-pot.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/Makefile.PL
+++ b/core/server/Makefile.PL
@@ -312,6 +312,7 @@ WriteMakefile(
     'Connector'              => '1.08',
     'Crypt::CBC'             => '2.29',
     'Crypt::OpenSSL::AES'    => '0.02',
+    'Crypt::PKCS10'          => '1',
     'DBD::Mock'              => '1.45',
 #    'DBI'                    => '1', # A prerequisite for Workflow, see below
     'Data::Password'         => '1.07',

--- a/core/server/bin/openxpkiadm
+++ b/core/server/bin/openxpkiadm
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/bin/openxpkicli
+++ b/core/server/bin/openxpkicli
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # Written by Oliver Welter
 # for the OpenXPKI project 2013

--- a/core/server/bin/openxpkicmd
+++ b/core/server/bin/openxpkicmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # Written by Martin Bartosch
 # extended by Oliver Welter

--- a/core/server/bin/openxpkictl
+++ b/core/server/bin/openxpkictl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/cgi-bin/scep
+++ b/core/server/cgi-bin/scep
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 ## CGI script for the OpenXPKI SCEP server
 ##
 ## Written by Oliver Welter OpenXPKI Project

--- a/core/server/cgi-bin/webui-mock.cgi
+++ b/core/server/cgi-bin/webui-mock.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/cgi-bin/webui.cgi
+++ b/core/server/cgi-bin/webui.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use CGI;
 use CGI::Session;

--- a/core/server/cgi-bin/webui.fcgi
+++ b/core/server/cgi-bin/webui.fcgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use CGI;
 use CGI::Fast;

--- a/package/suse/Makefile.inc
+++ b/package/suse/Makefile.inc
@@ -10,7 +10,7 @@ include $(TOPDIR)/package/common/Makefile.inc
 
 # standard directory for RPM builds, to override this use Makefile.local
 # or by setting it in your shell environment
-RPMBASE?=`rpm --eval '%{_topdir}'`
+RPMBASE?=$(shell rpm --eval '%{_topdir}')
 RPMBASE?=/usr/src/packages
 
 ifdef PREFIX

--- a/package/suse/cpan/cpandeps.pl
+++ b/package/suse/cpan/cpandeps.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # cpandeps.pl - Create include files for makefiles to set CPAN dependencies
 #

--- a/package/suse/myperl-apache-controller/Makefile
+++ b/package/suse/myperl-apache-controller/Makefile
@@ -1,0 +1,60 @@
+## Written 2006 by Martin Bartosch for the OpenXPKI project
+## Copyright (C) 2005-2011 by The OpenXPKI Project
+
+TOPDIR=../../..
+
+PERL_VERSION=5.20.0
+MYPERL_RELEASE=3
+
+PACKAGE=myperl-apache-controller
+#SRCBASE=$(TOPDIR)/clients/perl/OpenXPKI-Client-Enrollment
+SRCNAME=myperl-apache-controller
+
+# Makefile.inc contains common settings for all packages (checked in)
+include ../Makefile.inc
+# Makefile.local may be used locally to override settings (not checked in)
+-include ../Makefile.local
+
+all: clean package
+
+#all: clean perl-dist package collect
+
+dist-clean:
+#	( cd $(SRCBASE) && \
+#		rm -f *.tar.gz \
+#	)
+
+
+perl-dist: dist-clean
+#	cd $(SRCBASE) && perl Makefile.PL
+#	cd $(SRCBASE) && make dist
+#	mkdir -p $(RPMBASE)/SOURCES
+#	ls -l $(SRCBASE)/*.tar.gz
+#	mv $(SRCBASE)/*.tar.gz $(RPMBASE)/SOURCES
+
+$(PACKAGE).spec: $(PACKAGE).spec.template
+
+package: $(PACKAGE).spec
+	PERL_LOCAL_LIB_ROOT= PERL_MB_OPT= PERL_MM_OPT= rpmbuild -ba $(PACKAGE).spec
+
+collect:
+	mv $(RPMBASE)/SRPMS/$(PACKAGE)-*.rpm .
+	mv $(RPMBASE)/RPMS/*/$(PACKAGE)-*.rpm .
+
+clean:
+	rm -f $(PACKAGE)-*.rpm $(PACKAGE).spec
+
+#####
+# TODO: Move the following targets to a common makefile
+#####
+
+#TT_VERSION_SYMBOLS = \
+#					 --define PERL_VERSION="$(PERL_VERSION)" \
+#					 --define MYPERL_RELEASE="$(MYPERL_RELEASE)"
+#
+#.SUFFIXES: .template
+#
+#%:: %.template
+#	cat $< | tpage $(TT_VERSION_SYMBOLS) $(TT_EXTRA_SYMBOLS) >$@
+
+

--- a/package/suse/myperl-apache-controller/myperl-apache-controller.spec.template
+++ b/package/suse/myperl-apache-controller/myperl-apache-controller.spec.template
@@ -1,15 +1,16 @@
 ## Written 2006 by Martin Bartosch for the OpenXPKI project
-## Adapted for myperl-dbd-oracle by Scott Hardin
+## Adapted for myperl-dbd-mysql by Scott Hardin
 ## Copyright (C) 2005-2014 by The OpenXPKI Project
 
-%define pkgname myperl-dbd-oracle
+%define pkgname myperl-apache-controller
 %define filelist %{pkgname}-%{version}-filelist
 %define NVR %{pkgname}-%{version}-%{release}
 %define maketest 0
 %define __perl /opt/myperl/bin/perl
+%define __cpanm /opt/myperl/bin/cpanm
 
 name:      %{pkgname}
-summary:   DBD::Oracle packaged for myperl
+summary:   Apache Controller packaged for myperl
 version:   [% version %]
 [% IF PKGREL %]
 release: [% PKGREL %]
@@ -23,15 +24,13 @@ group:     Applications/CPAN
 url:       http://www.openxpki.org
 buildroot: %{_tmppath}/%{name}-%{version}-%(id -u -n)
 prefix:    %(echo %{_prefix})
-BuildRequires: myperl
+BuildRequires: myperl myperl-apache-mod-perl expat
 Requires: myperl
-# Some oracle installations are so complicated that they don't package the libcltsh.so directly,
-# but have some convoluted install script that unpacks it from somewhere else.
 AutoReqProv: no
 #source:    %{pkgname}-%{version}.tar.gz
 
 %description
-DBD::Oracle packaged for myperl
+Apache Controller packaged for myperl
 
 Packaging information:
 OpenXPKI version       [% version %]
@@ -68,8 +67,11 @@ VENDORARCH=`%{__perl} "-V:vendorarch" | awk -F\' '{print $2}'`
 VENDORLIBEXP=%{buildroot}/`%{__perl} "-V:vendorlibexp" | awk -F\' '{print $2}'`
 ARCHNAME=`%{__perl} "-V:archname" | awk -F\' '{print $2}'`
 ARCHLIB=`%{__perl} "-V:archlib" | awk -F\' '{print $2}'`
+VENDORMAN1EXP=`%{__perl} "-V:vendorman1direxp" | awk -F\' '{print $2}'`
+VENDORMAN3EXP=`%{__perl} "-V:vendorman3direxp" | awk -F\' '{print $2}'`
+VENDORSCRIPTEXP=`%{__perl} "-V:vendorscriptexp" | awk -F\' '{print $2}'`
 PRIVLIB=`%{__perl} "-V:privlib" | awk -F\' '{print $2}'`
-CPANM=/opt/myperl/bin/cpanm
+CPANM="%{__cpanm}"
 CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose $CPANM_MIRROR"
 
 # Environment vars neede for proper Perl module installation
@@ -78,8 +80,11 @@ export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs vendor"
 export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
 
-$CPANM $CPANM_OPTS Test::NoWarnings
-$CPANM $CPANM_OPTS Test::Tester Test::Deep DBD::Oracle
+#$CPANM $CPANM_OPTS Test::NoWarnings
+#$CPANM $CPANM_OPTS --installdeps Apache2::Request
+$CPANM $CPANM_OPTS Apache2::Request
+#(cd $HOME/.cpanm/latest-build/libapreq2-2.13 && %{__perl} Makefile.PL && ./configure --disable-static && make install)
+$CPANM $CPANM_OPTS Apache2::Cookie Apache2::Controller
 
 ## This next line does a regular CPAN-style install. Our Mojo app, however,
 ## needs to go in /srv/www/enroller and *not* with the other Perl modules.
@@ -108,6 +113,16 @@ find %{buildroot} -name "perllocal.pod" \
     -o -name ".packlist"                \
     -o -name "*.bs"                     \
     |xargs -i rm -f {}
+
+# myperl issue #2 kludge
+# Note: since this is a nasty kludge, leave the fail-on-error behavior of make.
+#
+# DESTDIR = %{buildroot}
+rm -rf \
+    $DESTDIR/opt/myperl/bin/config_data \
+    $DESTDIR/$VENDORMAN1EXP/config_data.1 \
+    $DESTDIR/$VENDORMAN3EXP/CGI* \
+    $DESTDIR/$VENDORMAN3EXP/Module::Build*
 
 # no empty directories
 #find %{buildroot}%{_prefix}             \

--- a/package/suse/myperl-apache-mod-perl/myperl-apache-mod-perl.spec.template
+++ b/package/suse/myperl-apache-mod-perl/myperl-apache-mod-perl.spec.template
@@ -25,6 +25,9 @@ buildroot: %{_tmppath}/%{name}-%{version}-%(id -u -n)
 prefix:    %(echo %{_prefix})
 BuildRequires: myperl
 Requires: myperl
+# The auto-prereq code picks up libexpat.so.0, but this is not explicitly
+# supplied by the libexpat1 SLES package.
+AutoReqProv: no
 #source:    %{pkgname}-%{version}.tar.gz
 
 %description
@@ -66,8 +69,8 @@ VENDORLIBEXP=%{buildroot}/`%{__perl} "-V:vendorlibexp" | awk -F\' '{print $2}'`
 ARCHNAME=`%{__perl} "-V:archname" | awk -F\' '{print $2}'`
 ARCHLIB=`%{__perl} "-V:archlib" | awk -F\' '{print $2}'`
 PRIVLIB=`%{__perl} "-V:privlib" | awk -F\' '{print $2}'`
-CPANM="%{__perl} `pwd`/cpanm"
-CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose"
+CPANM=/opt/myperl/bin/cpanm
+CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose $CPANM_MIRROR"
 
 # Environment vars neede for proper Perl module installation
 export PERL5LIB=%{buildroot}/$VENDORARCH:%{buildroot}/$VENDORLIB
@@ -75,11 +78,7 @@ export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs vendor"
 export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
 
-curl -LO http://xrl.us/cpanm
-chmod +x cpanm
-
-$CPANM $CPANM_OPTS Test::NoWarnings
-$CPANM $CPANM_OPTS Test::Tester Test::Deep mod_perl2
+$CPANM $CPANM_OPTS mod_perl2
 
 ## This next line does a regular CPAN-style install. Our Mojo app, however,
 ## needs to go in /srv/www/enroller and *not* with the other Perl modules.

--- a/package/suse/myperl-buildtools/Makefile
+++ b/package/suse/myperl-buildtools/Makefile
@@ -3,7 +3,7 @@
 
 TOPDIR=../../..
 
-PERL_VERSION=5.20.1
+PERL_VERSION=5.20.2
 MYPERL_RELEASE=1
 
 PACKAGE=myperl-buildtools

--- a/package/suse/myperl-buildtools/Makefile
+++ b/package/suse/myperl-buildtools/Makefile
@@ -1,0 +1,78 @@
+## Written 2006 by Martin Bartosch for the OpenXPKI project
+## Copyright (C) 2005-2011 by The OpenXPKI Project
+
+TOPDIR=../../..
+
+PERL_VERSION=5.20.1
+MYPERL_RELEASE=1
+
+PACKAGE=myperl-buildtools
+SRCNAME=myperl-buildtools
+
+# Makefile.inc contains common settings for all packages (checked in)
+#include ../Makefile.inc
+
+PERL := $(shell which perl)
+
+ifndef GIT_AUTHOR_NAME
+	GIT_AUTHOR_NAME := $(shell git config --get user.name)
+endif
+ifndef GIT_AUTHOR_EMAIL
+	GIT_AUTHOR_EMAIL := $(shell git config --get user.email)
+endif
+PACKAGER := $(strip $(GIT_AUTHOR_NAME) <$(GIT_AUTHOR_EMAIL)>)
+
+TT_VERSION_SYMBOLS = --define version="$(PERL_VERSION)" --define PKGREL=$(MYPERL_RELEASE) --define PACKAGER="$(PACKAGER)"
+.SUFFIXES: .template
+
+# For documentation in this implicit rule, see ../../common/Makefile.inc
+%:: %.template
+	cat $< | tpage $(TT_VERSION_SYMBOLS) $(TT_EXTRA_SYMBOLS) >$@.new
+	mv $@.new $@
+
+# Makefile.local may be used locally to override settings (not checked in)
+-include ../Makefile.local
+
+all: clean package
+
+#all: clean perl-dist package collect
+
+dist-clean:
+#	( cd $(SRCBASE) && \
+#		rm -f *.tar.gz \
+#	)
+
+
+perl-dist: dist-clean
+#	cd $(SRCBASE) && perl Makefile.PL
+#	cd $(SRCBASE) && make dist
+#	mkdir -p $(RPMBASE)/SOURCES
+#	ls -l $(SRCBASE)/*.tar.gz
+#	mv $(SRCBASE)/*.tar.gz $(RPMBASE)/SOURCES
+
+$(PACKAGE).spec: $(PACKAGE).spec.template
+
+package: $(PACKAGE).spec
+	PERL_LOCAL_LIB_ROOT= PERL_MB_OPT= PERL_MM_OPT= rpmbuild -ba $(PACKAGE).spec
+
+collect:
+	mv $(RPMBASE)/SRPMS/$(PACKAGE)-*.rpm .
+	mv $(RPMBASE)/RPMS/*/$(PACKAGE)-*.rpm .
+
+clean:
+	rm -f $(PACKAGE)-*.rpm $(PACKAGE).spec
+
+#####
+# TODO: Move the following targets to a common makefile
+#####
+
+#TT_VERSION_SYMBOLS = \
+#					 --define PERL_VERSION="$(PERL_VERSION)" \
+#					 --define MYPERL_RELEASE="$(MYPERL_RELEASE)"
+#
+#.SUFFIXES: .template
+#
+#%:: %.template
+#	cat $< | tpage $(TT_VERSION_SYMBOLS) $(TT_EXTRA_SYMBOLS) >$@
+
+

--- a/package/suse/myperl-buildtools/myperl-buildtools.spec.template
+++ b/package/suse/myperl-buildtools/myperl-buildtools.spec.template
@@ -1,15 +1,15 @@
 ## Written 2006 by Martin Bartosch for the OpenXPKI project
-## Adapted for myperl-dbd-oracle by Scott Hardin
+## Adapted for myperl-dbd-mysql by Scott Hardin
 ## Copyright (C) 2005-2014 by The OpenXPKI Project
 
-%define pkgname myperl-dbd-oracle
+%define pkgname myperl-buildtools
 %define filelist %{pkgname}-%{version}-filelist
 %define NVR %{pkgname}-%{version}-%{release}
 %define maketest 0
 %define __perl /opt/myperl/bin/perl
 
 name:      %{pkgname}
-summary:   DBD::Oracle packaged for myperl
+summary:   myperl build tools
 version:   [% version %]
 [% IF PKGREL %]
 release: [% PKGREL %]
@@ -25,13 +25,13 @@ buildroot: %{_tmppath}/%{name}-%{version}-%(id -u -n)
 prefix:    %(echo %{_prefix})
 BuildRequires: myperl
 Requires: myperl
-# Some oracle installations are so complicated that they don't package the libcltsh.so directly,
-# but have some convoluted install script that unpacks it from somewhere else.
+# The auto-prereq code picks up libexpat.so.0, but this is not explicitly
+# supplied by the libexpat1 SLES package.
 AutoReqProv: no
 #source:    %{pkgname}-%{version}.tar.gz
 
 %description
-DBD::Oracle packaged for myperl
+Various CPAN modules needed for building other myperl packages
 
 Packaging information:
 OpenXPKI version       [% version %]
@@ -78,8 +78,10 @@ export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs vendor"
 export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
 
-$CPANM $CPANM_OPTS Test::NoWarnings
-$CPANM $CPANM_OPTS Test::Tester Test::Deep DBD::Oracle
+# ExtUtils::MakeMaker needs to be 'forced' since an older version
+# is already installed
+$CPANM --notest --verbose ExtUtils::MakeMaker
+$CPANM $CPANM_OPTS Config::Std Test::NoWarnings Test::Tester Test::Deep
 
 ## This next line does a regular CPAN-style install. Our Mojo app, however,
 ## needs to go in /srv/www/enroller and *not* with the other Perl modules.
@@ -108,6 +110,21 @@ find %{buildroot} -name "perllocal.pod" \
     -o -name ".packlist"                \
     -o -name "*.bs"                     \
     |xargs -i rm -f {}
+
+# remove files that conflict with myperl base package
+echo "INFO: cleaning duplicate files from %{buildroot}%{_prefix}"
+(cd %{buildroot} && rm -f \
+    opt/myperl/bin/config_data \
+    opt/myperl/bin/instmodsh \
+    opt/myperl/man/man1/config_data.1 \
+    opt/myperl/man/man1/instmodsh.1 \
+    opt/myperl/man/man3/CPAN::*.3 \
+    opt/myperl/man/man3/ExtUtils::*.3 \
+    opt/myperl/man/man3/Module::Build*.3 \
+    opt/myperl/man/man3/Test::Builder*.3 \
+    opt/myperl/man/man3/Test::More.3 \
+    opt/myperl/man/man3/Test::Simple.3 \
+    opt/myperl/man/man3/Test::Tutorial.3 )
 
 # no empty directories
 #find %{buildroot}%{_prefix}             \

--- a/package/suse/myperl-dbd-mysql/myperl-dbd-mysql.spec.template
+++ b/package/suse/myperl-dbd-mysql/myperl-dbd-mysql.spec.template
@@ -66,17 +66,14 @@ VENDORLIBEXP=%{buildroot}/`%{__perl} "-V:vendorlibexp" | awk -F\' '{print $2}'`
 ARCHNAME=`%{__perl} "-V:archname" | awk -F\' '{print $2}'`
 ARCHLIB=`%{__perl} "-V:archlib" | awk -F\' '{print $2}'`
 PRIVLIB=`%{__perl} "-V:privlib" | awk -F\' '{print $2}'`
-CPANM="%{__perl} `pwd`/cpanm"
-CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose"
+CPANM=/opt/myperl/bin/cpanm
+CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose $CPANM_MIRROR"
 
 # Environment vars neede for proper Perl module installation
 export PERL5LIB=%{buildroot}/$VENDORARCH:%{buildroot}/$VENDORLIB
 export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs vendor"
 export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
-
-curl -LO http://xrl.us/cpanm
-chmod +x cpanm
 
 $CPANM $CPANM_OPTS Test::NoWarnings
 $CPANM $CPANM_OPTS Test::Tester Test::Deep DBD::mysql

--- a/package/suse/myperl-fcgi/Makefile
+++ b/package/suse/myperl-fcgi/Makefile
@@ -1,0 +1,60 @@
+## Written 2006 by Martin Bartosch for the OpenXPKI project
+## Copyright (C) 2005-2011 by The OpenXPKI Project
+
+TOPDIR=../../..
+
+PERL_VERSION=5.20.0
+MYPERL_RELEASE=3
+
+PACKAGE=myperl-fcgi
+#SRCBASE=$(TOPDIR)/clients/perl/OpenXPKI-Client-Enrollment
+SRCNAME=myperl-fcgi
+
+# Makefile.inc contains common settings for all packages (checked in)
+include ../Makefile.inc
+# Makefile.local may be used locally to override settings (not checked in)
+-include ../Makefile.local
+
+all: clean package
+
+#all: clean perl-dist package collect
+
+dist-clean:
+#	( cd $(SRCBASE) && \
+#		rm -f *.tar.gz \
+#	)
+
+
+perl-dist: dist-clean
+#	cd $(SRCBASE) && perl Makefile.PL
+#	cd $(SRCBASE) && make dist
+#	mkdir -p $(RPMBASE)/SOURCES
+#	ls -l $(SRCBASE)/*.tar.gz
+#	mv $(SRCBASE)/*.tar.gz $(RPMBASE)/SOURCES
+
+$(PACKAGE).spec: $(PACKAGE).spec.template
+
+package: $(PACKAGE).spec
+	PERL_LOCAL_LIB_ROOT= PERL_MB_OPT= PERL_MM_OPT= rpmbuild -ba $(PACKAGE).spec
+
+collect:
+	mv $(RPMBASE)/SRPMS/$(PACKAGE)-*.rpm .
+	mv $(RPMBASE)/RPMS/*/$(PACKAGE)-*.rpm .
+
+clean:
+	rm -f $(PACKAGE)-*.rpm $(PACKAGE).spec
+
+#####
+# TODO: Move the following targets to a common makefile
+#####
+
+#TT_VERSION_SYMBOLS = \
+#					 --define PERL_VERSION="$(PERL_VERSION)" \
+#					 --define MYPERL_RELEASE="$(MYPERL_RELEASE)"
+#
+#.SUFFIXES: .template
+#
+#%:: %.template
+#	cat $< | tpage $(TT_VERSION_SYMBOLS) $(TT_EXTRA_SYMBOLS) >$@
+
+

--- a/package/suse/myperl-fcgi/myperl-fcgi.spec.template
+++ b/package/suse/myperl-fcgi/myperl-fcgi.spec.template
@@ -1,15 +1,15 @@
 ## Written 2006 by Martin Bartosch for the OpenXPKI project
-## Adapted for myperl-dbd-oracle by Scott Hardin
+## Adapted for myperl-dbd-mysql by Scott Hardin
 ## Copyright (C) 2005-2014 by The OpenXPKI Project
 
-%define pkgname myperl-dbd-oracle
+%define pkgname myperl-fcgi
 %define filelist %{pkgname}-%{version}-filelist
 %define NVR %{pkgname}-%{version}-%{release}
 %define maketest 0
 %define __perl /opt/myperl/bin/perl
 
 name:      %{pkgname}
-summary:   DBD::Oracle packaged for myperl
+summary:   Apache fcgi packaged for myperl
 version:   [% version %]
 [% IF PKGREL %]
 release: [% PKGREL %]
@@ -25,13 +25,13 @@ buildroot: %{_tmppath}/%{name}-%{version}-%(id -u -n)
 prefix:    %(echo %{_prefix})
 BuildRequires: myperl
 Requires: myperl
-# Some oracle installations are so complicated that they don't package the libcltsh.so directly,
-# but have some convoluted install script that unpacks it from somewhere else.
+# The auto-prereq code picks up libexpat.so.0, but this is not explicitly
+# supplied by the libexpat1 SLES package.
 AutoReqProv: no
 #source:    %{pkgname}-%{version}.tar.gz
 
 %description
-DBD::Oracle packaged for myperl
+Apache fcgi packaged for myperl
 
 Packaging information:
 OpenXPKI version       [% version %]
@@ -78,8 +78,7 @@ export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs vendor"
 export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
 
-$CPANM $CPANM_OPTS Test::NoWarnings
-$CPANM $CPANM_OPTS Test::Tester Test::Deep DBD::Oracle
+$CPANM $CPANM_OPTS FCGI
 
 ## This next line does a regular CPAN-style install. Our Mojo app, however,
 ## needs to go in /srv/www/enroller and *not* with the other Perl modules.

--- a/package/suse/myperl-inline-c/Makefile
+++ b/package/suse/myperl-inline-c/Makefile
@@ -1,0 +1,60 @@
+## Written 2006 by Martin Bartosch for the OpenXPKI project
+## Copyright (C) 2005-2011 by The OpenXPKI Project
+
+TOPDIR=../../..
+
+PERL_VERSION=5.20.0
+MYPERL_RELEASE=1
+
+PACKAGE=myperl-inline-c
+#SRCBASE=$(TOPDIR)/clients/perl/OpenXPKI-Client-Enrollment
+SRCNAME=myperl-inline-c
+
+# Makefile.inc contains common settings for all packages (checked in)
+include ../Makefile.inc
+# Makefile.local may be used locally to override settings (not checked in)
+-include ../Makefile.local
+
+all: clean package
+
+#all: clean perl-dist package collect
+
+dist-clean:
+#	( cd $(SRCBASE) && \
+#		rm -f *.tar.gz \
+#	)
+
+
+perl-dist: dist-clean
+#	cd $(SRCBASE) && perl Makefile.PL
+#	cd $(SRCBASE) && make dist
+#	mkdir -p $(RPMBASE)/SOURCES
+#	ls -l $(SRCBASE)/*.tar.gz
+#	mv $(SRCBASE)/*.tar.gz $(RPMBASE)/SOURCES
+
+$(PACKAGE).spec: $(PACKAGE).spec.template
+
+package: $(PACKAGE).spec
+	PERL_LOCAL_LIB_ROOT= PERL_MB_OPT= PERL_MM_OPT= rpmbuild -ba $(PACKAGE).spec
+
+collect:
+	mv $(RPMBASE)/SRPMS/$(PACKAGE)-*.rpm .
+	mv $(RPMBASE)/RPMS/*/$(PACKAGE)-*.rpm .
+
+clean:
+	rm -f $(PACKAGE)-*.rpm $(PACKAGE).spec
+
+#####
+# TODO: Move the following targets to a common makefile
+#####
+
+#TT_VERSION_SYMBOLS = \
+#					 --define PERL_VERSION="$(PERL_VERSION)" \
+#					 --define MYPERL_RELEASE="$(MYPERL_RELEASE)"
+#
+#.SUFFIXES: .template
+#
+#%:: %.template
+#	cat $< | tpage $(TT_VERSION_SYMBOLS) $(TT_EXTRA_SYMBOLS) >$@
+
+

--- a/package/suse/myperl-inline-c/myperl-inline-c.spec.template
+++ b/package/suse/myperl-inline-c/myperl-inline-c.spec.template
@@ -1,15 +1,15 @@
 ## Written 2006 by Martin Bartosch for the OpenXPKI project
-## Adapted for myperl-dbd-oracle by Scott Hardin
+## Adapted for myperl-inline-c by Scott Hardin
 ## Copyright (C) 2005-2014 by The OpenXPKI Project
 
-%define pkgname myperl-dbd-oracle
+%define pkgname myperl-inline-c
 %define filelist %{pkgname}-%{version}-filelist
 %define NVR %{pkgname}-%{version}-%{release}
 %define maketest 0
 %define __perl /opt/myperl/bin/perl
 
 name:      %{pkgname}
-summary:   DBD::Oracle packaged for myperl
+summary:   Inline packaged for myperl
 version:   [% version %]
 [% IF PKGREL %]
 release: [% PKGREL %]
@@ -25,13 +25,10 @@ buildroot: %{_tmppath}/%{name}-%{version}-%(id -u -n)
 prefix:    %(echo %{_prefix})
 BuildRequires: myperl
 Requires: myperl
-# Some oracle installations are so complicated that they don't package the libcltsh.so directly,
-# but have some convoluted install script that unpacks it from somewhere else.
-AutoReqProv: no
 #source:    %{pkgname}-%{version}.tar.gz
 
 %description
-DBD::Oracle packaged for myperl
+Inline packaged for myperl
 
 Packaging information:
 OpenXPKI version       [% version %]
@@ -70,7 +67,7 @@ ARCHNAME=`%{__perl} "-V:archname" | awk -F\' '{print $2}'`
 ARCHLIB=`%{__perl} "-V:archlib" | awk -F\' '{print $2}'`
 PRIVLIB=`%{__perl} "-V:privlib" | awk -F\' '{print $2}'`
 CPANM=/opt/myperl/bin/cpanm
-CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose $CPANM_MIRROR"
+CPANM_OPTS="--notest --skip-satisfied ExtUtils::MakeMaker --skip-installed --verbose $CPANM_MIRROR"
 
 # Environment vars neede for proper Perl module installation
 export PERL5LIB=%{buildroot}/$VENDORARCH:%{buildroot}/$VENDORLIB
@@ -78,8 +75,8 @@ export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs vendor"
 export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
 
-$CPANM $CPANM_OPTS Test::NoWarnings
-$CPANM $CPANM_OPTS Test::Tester Test::Deep DBD::Oracle
+#$CPANM $CPANM_OPTS Test::NoWarnings
+$CPANM $CPANM_OPTS Inline::C
 
 ## This next line does a regular CPAN-style install. Our Mojo app, however,
 ## needs to go in /srv/www/enroller and *not* with the other Perl modules.

--- a/package/suse/myperl-openxpki-core-deps/myperl-openxpki-core-deps.spec.template
+++ b/package/suse/myperl-openxpki-core-deps/myperl-openxpki-core-deps.spec.template
@@ -64,8 +64,8 @@ VENDORMAN1EXP=`%{__perl} "-V:vendorman1direxp" | awk -F\' '{print $2}'`
 VENDORMAN3EXP=`%{__perl} "-V:vendorman3direxp" | awk -F\' '{print $2}'`
 VENDORSCRIPTEXP=`%{__perl} "-V:vendorscriptexp" | awk -F\' '{print $2}'`
 PRIVLIB=`%{__perl} "-V:privlib" | awk -F\' '{print $2}'`
-CPANM="%{__perl} `pwd`/cpanm"
-CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose"
+CPANM=/opt/myperl/bin/cpanm
+CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose $CPANM_MIRROR"
 
 # Environment vars neede for proper Perl module installation
 export PERL5LIB=%{buildroot}/$VENDORARCH:%{buildroot}/$VENDORLIB
@@ -74,9 +74,6 @@ export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 # Keep Module::Install from trying to install stuff itself using cpanplus or cpan
 export PERL_AUTOINSTALL="--skip"
 export DESTDIR="%{buildroot}"
-
-curl -LO http://xrl.us/cpanm
-chmod +x cpanm
 
 $CPANM $CPANM_OPTS Class::Std Config::Std
 echo "DEBUG: current directory = `pwd`"

--- a/package/suse/myperl-openxpki-core/myperl-openxpki-core.spec.template
+++ b/package/suse/myperl-openxpki-core/myperl-openxpki-core.spec.template
@@ -61,8 +61,8 @@ PERL=%{__perl}
 
 install -d -D -m 755 %{buildroot}/opt/myperl/share/cgi-bin
 install -d -D -m 755 %{buildroot}/opt/myperl/share/htdocs
-tar cf - cgi-bin | tar -C %{buildroot}/opt/myperl/share/ -x -f -
-tar cf - htdocs | tar -C %{buildroot}/opt/myperl/share/ -x -f -
+tar cf - -C core/server cgi-bin | tar -C %{buildroot}/opt/myperl/share/ -x -f -
+tar cf - -C core/server htdocs | tar -C %{buildroot}/opt/myperl/share/ -x -f -
 
 VENDORLIB=`%{__perl} "-V:vendorlib" | awk -F\' '{print $2}'`
 VENDORARCH=`%{__perl} "-V:vendorarch" | awk -F\' '{print $2}'`

--- a/package/suse/myperl-openxpki-core/myperl-openxpki-core.spec.template
+++ b/package/suse/myperl-openxpki-core/myperl-openxpki-core.spec.template
@@ -26,6 +26,9 @@ prefix:    %(echo %{_prefix})
 BuildRequires: myperl
 Requires: myperl
 source:    %{pkgname}-%{version}.tar.gz
+# Some local installations are complicated and don't have the various
+# prereqs declared correctly, so we disable the automatic prereq checking.
+AutoReqProv: no
 
 %description
 OpenXPKI Core
@@ -65,17 +68,14 @@ VENDORMAN1EXP=`%{__perl} "-V:vendorman1direxp" | awk -F\' '{print $2}'`
 VENDORMAN3EXP=`%{__perl} "-V:vendorman3direxp" | awk -F\' '{print $2}'`
 VENDORSCRIPTEXP=`%{__perl} "-V:vendorscriptexp" | awk -F\' '{print $2}'`
 PRIVLIB=`%{__perl} "-V:privlib" | awk -F\' '{print $2}'`
-CPANM="%{__perl} `pwd`/cpanm"
-CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose"
+CPANM=/opt/myperl/bin/cpanm
+CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose $CPANM_MIRROR"
 
 # Environment vars neede for proper Perl module installation
 export PERL5LIB=%{buildroot}/$VENDORARCH:%{buildroot}/$VENDORLIB
 export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs vendor"
 export PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
-
-curl -LO http://xrl.us/cpanm
-chmod +x cpanm
 
 #$CPANM $CPANM_OPTS Class::Std Config::Std
 echo "DEBUG: current directory = `pwd`"

--- a/package/suse/myperl-openxpki-core/myperl-openxpki-core.spec.template
+++ b/package/suse/myperl-openxpki-core/myperl-openxpki-core.spec.template
@@ -59,6 +59,11 @@ set -o errexit
 
 PERL=%{__perl}
 
+install -d -D -m 755 %{buildroot}/opt/myperl/share/cgi-bin
+install -d -D -m 755 %{buildroot}/opt/myperl/share/htdocs
+tar cf - cgi-bin | tar -C %{buildroot}/opt/myperl/share/ -x -f -
+tar cf - htdocs | tar -C %{buildroot}/opt/myperl/share/ -x -f -
+
 VENDORLIB=`%{__perl} "-V:vendorlib" | awk -F\' '{print $2}'`
 VENDORARCH=`%{__perl} "-V:vendorarch" | awk -F\' '{print $2}'`
 VENDORLIBEXP=%{buildroot}/`%{__perl} "-V:vendorlibexp" | awk -F\' '{print $2}'`

--- a/package/suse/myperl-openxpki-enroll-deps/myperl-openxpki-enroll-deps.spec.template
+++ b/package/suse/myperl-openxpki-enroll-deps/myperl-openxpki-enroll-deps.spec.template
@@ -60,17 +60,14 @@ SITEMAN1EXP=`%{__perl} "-V:siteman1direxp" | awk -F\' '{print $2}'`
 SITEMAN3EXP=`%{__perl} "-V:siteman3direxp" | awk -F\' '{print $2}'`
 SITESCRIPTEXP=`%{__perl} "-V:sitescriptexp" | awk -F\' '{print $2}'`
 PRIVLIB=`%{__perl} "-V:privlib" | awk -F\' '{print $2}'`
-CPANM="%{__perl} `pwd`/cpanm"
-CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose"
+CPANM=/opt/myperl/bin/cpanm
+CPANM_OPTS="--notest --skip-satisfied --skip-installed --verbose $CPANM_MIRROR"
 
 # Environment vars neede for proper Perl module installation
 export PERL5LIB=%{buildroot}/$SITEARCH:%{buildroot}/$SITELIB
 export PERL_MB_OPT="--destdir '%{buildroot}' --installdirs site"
 export PERL_MM_OPT="INSTALLDIRS=site DESTDIR=%{buildroot}"
 export DESTDIR="%{buildroot}"
-
-curl -LO http://xrl.us/cpanm
-chmod +x cpanm
 
 $CPANM $CPANM_OPTS Class::Std Config::Std
 echo "DEBUG: current directory = `pwd`"

--- a/package/suse/myperl-openxpki-i18n/Makefile
+++ b/package/suse/myperl-openxpki-i18n/Makefile
@@ -1,0 +1,69 @@
+## Written 2014 by Scott Hardin for the OpenXPKI project
+## Copyright (C) 2014 by The OpenXPKI Project
+
+############################################################
+# VARIABLES
+############################################################
+
+TOPDIR			:= ../../..
+
+PACKAGE			:= myperl-openxpki-i18n
+SRCBASE			:= $(TOPDIR)/core/i18n
+SRCNAME			:= $(PACKAGE)
+
+ifndef PERL_VERSION
+PERL_VERSION		:= 5.20.0
+endif
+
+ifndef MYPERL_RELEASE
+MYPERL_RELEASE		:= 1
+endif
+
+OXI_VERSION 		:= $(shell ../../../tools/vergen --format version)
+
+# Makefile.inc contains common settings for all packages (checked in)
+include ../Makefile.inc
+# Makefile.local may be used locally to override settings (not checked in)
+-include ../Makefile.local
+
+SRC_TARBALL 		:= $(RPMBASE)/SOURCES/$(PACKAGE)-$(OXI_VERSION).tar.gz
+SRC_TARBALL_DIR 	:= $(RPMBASE)/BUILD/tmp/$(PACKAGE)-$(OXI_VERSION)
+
+############################################################
+# TARGETS
+############################################################
+
+all: clean package
+
+$(PACKAGE).spec: $(PACKAGE).spec.template
+
+package: $(PACKAGE).spec $(SRC_TARBALL)
+	PERL_LOCAL_LIB_ROOT= PERL_MB_OPT= PERL_MM_OPT= rpmbuild -ba $(PACKAGE).spec
+
+collect:
+	mv $(RPMBASE)/SRPMS/$(PACKAGE)-*.rpm .
+	mv $(RPMBASE)/RPMS/*/$(PACKAGE)-*.rpm .
+
+clean:
+	rm -f $(PACKAGE)-*.rpm $(PACKAGE).spec $(OXI_TARBALL)
+
+$(SRC_TARBALL):
+	cd $(SRCBASE)/ \
+		&& make scan PACKAGE=$(PACKAGE) \
+		&& make dist PACKAGE=$(PACKAGE) \
+		&& mv $(PACKAGE)-$(OXI_VERSION).tar.gz \
+		$(RPMBASE)/SOURCES/$(notdir $(SRC_TARBALL))
+
+#$(OXI_TARBALL):
+#	rm -rf $(OXI_TARBALL_DIR)
+#	mkdir -p $(OXI_TARBALL_DIR)
+#	(cd ../../.. && tar cf - \
+#		ISSUES LICENSE README.pod clients config core doc package qatest tools) \
+#		| tar xf - -C $(OXI_TARBALL_DIR)
+#	echo $(OXI_VERSION) > $(OXI_TARBALL_DIR)/VERSION
+#	tar czf $@ -C $(OXI_TARBALL_DIR)/.. .
+
+debug:
+	@echo "OXI_VERSION = $(OXI_VERSION)"
+	@echo "RPMBASE = $(RPMBASE)"
+	@echo "SRC_TARBALL = $(SRC_TARBALL)"

--- a/package/suse/myperl-openxpki-i18n/myperl-openxpki-i18n.spec.template
+++ b/package/suse/myperl-openxpki-i18n/myperl-openxpki-i18n.spec.template
@@ -1,0 +1,134 @@
+## Written 2006 by Martin Bartosch for the OpenXPKI project
+## Adapted for myperl-openxpki-core-deps by Scott Hardin
+## Copyright (C) 2005-2014 by The OpenXPKI Project
+
+%define pkgname myperl-openxpki-i18n
+%define filelist %{pkgname}-%{version}-filelist
+%define NVR %{pkgname}-%{version}-%{release}
+%define maketest 0
+%define __perl /opt/myperl/bin/perl
+
+name:      %{pkgname}
+summary:   OpenXPKI Internationalization
+version:   [% version %]
+[% IF PKGREL %]
+release: [% PKGREL %]
+[% ELSE %]
+release:   1
+[% END %]
+vendor:    OpenXPKI Project
+packager:  Scott Hardin <scott@hnsc.de>
+license:   Apache
+group:     Applications/CPAN
+url:       http://www.openxpki.org
+buildroot: %{_tmppath}/%{name}-%{version}-%(id -u -n)
+prefix:    %(echo %{_prefix})
+BuildRequires: myperl
+Requires: myperl
+source:    %{pkgname}-%{version}.tar.gz
+# Some local installations are complicated and don't have the various
+# prereqs declared correctly, so we disable the automatic prereq checking.
+AutoReqProv: no
+
+%description
+OpenXPKI internationalization files
+
+OpenXPKI is an Open Source PKI project.
+
+Packaging information:
+OpenXPKI version       [% version %]
+Git commit hash:       [% GIT_COMMIT_HASH %]
+Git description:       [% GIT_DESCRIPTION %]
+Git tags:              [%- IF GIT_TAGS -%]
+[%- GIT_TAGS -%]
+[%- ELSE -%]
+<no tag set>
+[%- END %]
+
+%prep
+%setup -q -n %{pkgname}-%{version} 
+chmod -R u+w %{_builddir}/%{pkgname}-%{version}
+
+%build
+%{__make}
+%if %maketest
+%{__make} test
+%endif
+
+%install
+[ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
+set -o errexit
+
+%{makeinstall} DESTDIR=%{buildroot} PREFIX=/opt/myperl
+
+cmd=/usr/share/spec-helper/compress_files
+[ -x $cmd ] || cmd=/usr/lib/rpm/brp-compress
+[ -x $cmd ] && $cmd
+
+# SuSE Linux
+if [ -e /etc/SuSE-release -o -e /etc/UnitedLinux-release ]
+then
+	:
+fi
+
+# remove special files
+
+# no empty directories
+#find %{buildroot}%{_prefix}             \
+#    -type d -depth                      \
+#    -exec rmdir {} \; 2>/dev/null
+
+%{__perl} -MFile::Find -le '
+    find({ wanted => \&wanted, no_chdir => 1}, "%{buildroot}");
+    #print "%doc  CHANGES INSTALL LICENSE README";
+    for my $x (sort @dirs, @files) {
+        push @ret, $x unless indirs($x);
+        }
+    print join "\n", sort @ret;
+
+    sub wanted {
+        return if /auto$/;
+
+        local $_ = $File::Find::name;
+        my $f = $_; s|^\Q%{buildroot}\E||;
+        return unless length;
+        return $files[@files] = $_ if -f $f;
+
+        $d = $_;
+        /\Q$d\E/ && return for reverse sort @INC;
+        $d =~ /\Q$_\E/ && return
+            for qw|/etc %_prefix/man %_prefix/bin %_prefix/share|;
+
+        $dirs[@dirs] = $_;
+        }
+
+    sub indirs {
+        my $x = shift;
+        $x =~ /^\Q$_\E\// && $x ne $_ && return 1 for @dirs;
+        }
+    ' > %filelist
+
+
+[ -z %filelist ] && {
+    echo "ERROR: empty %files listing"
+    exit -1
+    }
+
+
+%clean
+#[ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
+
+%files -f %filelist
+%defattr(-,root,root)
+
+#%attr(0755,root,openxpki) /srv/www/openxpki/mason-data
+
+%changelog
+* Wed Aug 06 2014 scott.hardin@hnsc.de
+- update for new myperl-style packaging
+* Mon Aug 15 2011 m.bartosch@cynops.de
+- Fixed file permissions in package
+* Thu Feb 03 2011 m.bartosch@cynops.de
+- Renovated build process, using generic template mechanism
+* Mon Nov 27 2006 m.bartosch@cynops.de
+- Initial build.

--- a/qatest/t/certhelper.t
+++ b/qatest/t/certhelper.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/automated_test_reports/generate_report.pl
+++ b/tools/automated_test_reports/generate_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/automated_test_reports/run_test.pl
+++ b/tools/automated_test_reports/run_test.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/automated_test_reports/update_svn_and_test.pl
+++ b/tools/automated_test_reports/update_svn_and_test.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/scripts/ogflow.pl
+++ b/tools/scripts/ogflow.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/perl -w
 #
 # ogflow.pl - Convert OmniGraffle File to Workflow Definition
 #

--- a/tools/vergen
+++ b/tools/vergen
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # Written by Martin Bartosch for the OpenXPKI project 2006
 # Copyright (c) 2006-2011 by The OpenXPKI Project

--- a/vagrant/opensuse/README.mkd
+++ b/vagrant/opensuse/README.mkd
@@ -1,0 +1,29 @@
+# Building RPM Packages for (Open)SuSE
+
+This vagrant configuration is used for creating RPM packages on
+OpenSuSE and SuSE.
+
+# Prerequisites
+
+On your development workstation, you'll need the following
+
+* VirtualBox
+* Vagrant
+* Local Git repository clones:
+  * ~/git/myperl
+  * ~/git/openxpki
+
+# Quickstart
+
+TIP: The 'git clone' in the vagrant build instance will set the current
+branch to the one current in your working repository in ~/git/myperl and
+~/git/openxpki, so be sure you have the correct branch checked out there.
+
+To build myperl and the openxpki core packages, run the following:
+
+	vagrant up build
+	vagrant ssh build --command '/vagrant/build.mk git-clone'
+	vagrant ssh build --command '/vagrant/build.mk myperl'
+	vagrant ssh build --command '/vagrant/build.mk myperl-buildtools'
+	vagrant ssh build --command '/vagrant/build.mk myperl-openxpki-core-deps'
+	vagrant ssh build --command '/vagrant/build.mk myperl-openxpki-core'

--- a/vagrant/opensuse/Vagrantfile
+++ b/vagrant/opensuse/Vagrantfile
@@ -16,13 +16,15 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   #config.vm.box = "deb-wheezy-amd64"
-  config.vm.box = "opensuse-12-3-x64"
+  config.vm.box = "opensuse-12.3-64"
 
   # Details about the box: https://github.com/mapleoin/openSUSE-vagrant-box
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
+#  config.vm.box_url =
+#      "http://bit.ly/openSUSE-12-3-virtualbox-box"
   config.vm.box_url =
-      "http://bit.ly/openSUSE-12-3-virtualbox-box"
+	"http://sourceforge.net/projects/opensusevagrant/files/12.3/opensuse-12.3-64.box/download"
 
 #  if config_values[:mirrors]
 #    config.vm.synced_folder config_values[:mirrors], "/mirrors"

--- a/vagrant/opensuse/build.mk
+++ b/vagrant/opensuse/build.mk
@@ -1,0 +1,209 @@
+#!/usr/bin/make -f
+#
+# build.mk - used on build host (e.g. in vagrant instance) to build packages
+#
+
+GREP	:= $(shell which grep)
+AWK		:= $(shell which awk)
+SORT	:= $(shell which sort)
+PR		:= $(shell which pr)
+CURRENT_MAKEFILE := $(word $(words $(MAKEFILE_LIST)), $(MAKEFILE_LIST))
+
+SUDO := sudo
+
+PINTO_DIR := /pinto
+USE_PINTO := $(wildcard $(PINTO_DIR)/stacks/oxibld)
+
+ifdef USE_PINTO
+export CPANM_MIRROR := --mirror file:/$(PINTO_DIR)/stacks/oxibld --mirror-only
+endif
+
+DEP.MYPERL.VER := 5.20.2
+DEP.MYPERL.REL := 1
+DEP.MYPERL.GITURI := /git/myperl
+DEP.MYPERL.GITDIR := $(HOME)/git/myperl
+
+TARGET_ARCH := $(shell rpmbuild --eval='%{_target_cpu}' 2>/dev/null)
+
+PERL_SRCBASE := http://ftp.gwdg.de/pub/languags/perl/CPAN/src/5.0
+PERL_SRCBASE := http://www.cpan.org/src/5.0
+PERL_TARBALL := perl-$(DEP.MYPERL.VER).tar.bz2
+
+OPENXPKI.GITURI := /git/openxpki
+OPENXPKI.GITDIR := $(HOME)/git/openxpki
+OPENXPKI.VER := $(shell cd $(OPENXPKI.GITDIR) && $(OPENXPKI.GITDIR)/tools/vergen --format version)
+
+#CODE_DIR := $(HOME)/git/openxpki
+#CODE_VER := $(shell cd $(CODE_DIR) && $(CODE_DIR)/tools/vergen --format version)
+
+CONF_DIR := $(HOME)/git/config
+CONF_VER := $(shell cd $(CONF_DIR) && $(OPENXPKI.GITDIR)/tools/vergen --format version)
+
+DEP.CRYPT_ECDH.GITURI := /git/crypt-ecdh
+DEP.CRYPT_ECDH.GITDIR := $(HOME)/git/crypt-ecdh
+
+
+# The TARGET_ALIASES are the short alias names for each of the
+# packages to be built
+
+TARGET_ALIASES := myperl myperl-buildtools myperl-inline-c myperl-fcgi myperl-openxpki-core-deps myperl-openxpki-core myperl-openxpki-i18n
+
+VAGRANT_RPMS := \
+	$(patsubst %,/vagrant/rpms/%,\
+	myperl-$(DEP.MYPERL.VER)-$(DEP.MYPERL.REL).$(TARGET_ARCH).rpm \
+	myperl-apache-mod-perl-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm \
+	myperl-apache-controller-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm \
+	myperl-inline-c-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm \
+	myperl-fcgi-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm \
+	myperl-openxpki-core-deps-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm \
+	myperl-openxpki-i18n-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm \
+	)
+
+RPMBUILD_RPMS := \
+	$(patsubst /vagrant/rpms/%,$(HOME)/rpmbuild/RPMS/$(TARGET_ARCH)/%,$(VAGRANT_RPMS))
+
+# $(call assert,condition,message)
+define assert
+  $(if $1,,$(error Assertion failed: $2))
+endef
+# $(call assert-not-installed,rpm-name)
+define assert-not-installed
+	@rpm -qi --quiet $1; test $$? = 1 || \
+		(echo "ERROR: $1 already installed"; exit 1)
+endef
+
+define filename-to-packagename
+$(patsubst %-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm,%,$(notdir $1))
+endef
+
+.PHONY: help
+help:
+	@echo "The following make targets are available: "
+	@echo 
+	@$(MAKE) -f $(CURRENT_MAKEFILE)						\
+	   	--print-data-base --question no-such-target		\
+		2>&1 |											\
+	$(GREP) -v -e 'no-such-target' -e '^makefile' |	\
+	$(AWK) '/^[^.%][-A-Za-z0-9_]*:/						\
+		{ print substr($$1, 1, length($$1)-1) }' |		\
+	$(SORT) |											\
+	$(PR) --omit-pagination --width=80 --columns=4
+
+info:
+	@echo "MAKE=$(MAKE)"
+	@echo "GREP=$(GREP)"
+	@echo "AWK=$(AWK)"
+	@echo "SORT=$(SORT)"
+	@echo "PR=$(PR)"
+	@echo "MAKEFILE_LIST=$(MAKEFILE_LIST)"
+
+debug:
+	@echo "OPENXPKI.GITDIR = $(OPENXPKI.GITDIR)"
+	@echo "OPENXPKI.VER = $(OPENXPKI.VER)"
+	@echo "CONF_DIR = $(CONF_DIR)"
+	@echo "CONF_VER = $(CONF_VER)"
+	@echo "VAGRANT_RPMS = $(VAGRANT_RPMS)"
+	@echo "RPMBUILD_RPMS = $(RPMBUILD_RPMS)"
+	@echo "CPANM_MIRROR (env) = $$CPANM_MIRROR"
+
+#all: $(VAGRANT_RPMS)
+all: $(TARGET_ALIASES)
+
+clean:
+	cd $(DEP.MYPERL.GITDIR) && make suse-clean
+	rm -rf $(VAGRANT_RPMS) $(RPMBUILD_RPMS)
+	-sudo rpm -e myperl
+
+# This helper takes care of cloning all the needed repos
+git-clone: $(DEP.MYPERL.GITDIR) $(OPENXPKI.GITDIR) $(DEP.KEYNANNY.GITDIR) 
+
+$(DEP.MYPERL.GITDIR):
+	git clone $(DEP.MYPERL.GITURI) $(DEP.MYPERL.GITDIR)
+
+$(OPENXPKI.GITDIR):
+	git clone $(OPENXPKI.GITURI) $(OPENXPKI.GITDIR)
+
+$(DEP.KEYNANNY.GITDIR):
+	git clone $(DEP.KEYNANNY.GITURI) $(DEP.KEYNANNY.GITDIR)
+
+git-pull:
+	cd $(DEP.MYPERL.GITDIR) && git pull --ff-only
+	cd $(OPENXPKI.GITDIR) && git pull --ff-only
+	cd $(DEP.KEYNANNY.GITDIR) && git pull --ff-only
+
+myperl: /vagrant/rpms/myperl-$(DEP.MYPERL.VER)-$(DEP.MYPERL.REL).$(TARGET_ARCH).rpm
+
+ifdef USE_PINTO
+$(PINTO_DIR)/$(PERL_TARBALL):
+	wget -O $@ $(PERL_SRCBASE)/$(PERL_TARBALL)
+
+$(PINTO_DIR)/cpanm:
+	wget -O $@ https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm
+
+$(DEP.MYPERL.GITDIR)/$(PERL_TARBALL): $(PINTO_DIR)/$(PERL_TARBALL)
+	cp -a $< $@
+
+$(DEP.MYPERL.GITDIR)/cpanm: $(PINTO_DIR)/cpanm
+	cp -a $< $@
+endif
+
+/vagrant/rpms:
+	mkdir $@
+
+/vagrant/rpms/myperl-$(DEP.MYPERL.VER)-$(DEP.MYPERL.REL).$(TARGET_ARCH).rpm: \
+		/vagrant/rpms \
+		$(DEP.MYPERL.GITDIR) 
+	$(call assert-not-installed,myperl)
+	cd $(DEP.MYPERL.GITDIR) && make fetch-perl suse
+	cp $(HOME)/rpmbuild/RPMS/$(TARGET_ARCH)/$(notdir $@) $@
+	$(SUDO) rpm -ivh --oldpackage --replacepkgs $@
+
+ifdef USE_PINTO
+/vagrant/rpms/myperl-$(DEP.MYPERL.VER)-$(DEP.MYPERL.REL).$(TARGET_ARCH).rpm: \
+		$(DEP.MYPERL.GITDIR)/$(PERL_TARBALL) \
+		$(DEP.MYPERL.GITDIR)/cpanm 
+endif
+
+myperl-buildtools: /vagrant/rpms/myperl-buildtools-$(DEP.MYPERL.VER)-$(DEP.MYPERL.REL).$(TARGET_ARCH).rpm
+
+/vagrant/rpms/myperl-buildtools-$(DEP.MYPERL.VER)-$(DEP.MYPERL.REL).$(TARGET_ARCH).rpm:
+	$(call assert-not-installed,$(call filename-to-packagename,myperl-buildtools))
+	$(call assert,$(OPENXPKI.VER),Need to run 'git-clone' target)
+	cd $(OPENXPKI.GITDIR)/package/suse/$(call filename-to-packagename,myperl-buildtools) && \
+		PERL5LIB=\$$HOME/perl5/lib/perl5/ make
+	cp $(HOME)/rpmbuild/RPMS/$(TARGET_ARCH)/$(notdir $@) $@
+	$(SUDO) rpm -ivh --oldpackage --replacepkgs $@
+	
+
+# Plan-B
+plan-b: /vagrant/rpms/myperl-openxpki-client-html-mason-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+
+.PHONY: myperl-apache-mod-perl myperl-apache-controller myperl-inline-c myperl-fcgi myperl-dbd-oracle
+
+myperl-apache-mod-perl: /vagrant/rpms/myperl-apache-mod-perl-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+myperl-apache-controller: /vagrant/rpms/myperl-apache-controller-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+myperl-inline-c: /vagrant/rpms/myperl-inline-c-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+myperl-fcgi: /vagrant/rpms/myperl-fcgi-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+myperl-dbd-oracle: /vagrant/rpms/myperl-dbd-oracle-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+myperl-openxpki-core-deps: /vagrant/rpms/myperl-openxpki-core-deps-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+myperl-openxpki-core: /vagrant/rpms/myperl-openxpki-core-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+myperl-openxpki-i18n: /vagrant/rpms/myperl-openxpki-i18n-$(OPENXPKI.VER)-1.$(TARGET_ARCH).rpm
+
+%.rpm: $(OPENXPKI.GITDIR)
+	$(call assert-not-installed,$(call filename-to-packagename,$@))
+	$(call assert,$(OPENXPKI.VER),Need to run 'git-clone' target)
+	cd $(OPENXPKI.GITDIR)/package/suse/$(call filename-to-packagename,$@) && \
+		PERL5LIB=\$$HOME/perl5/lib/perl5/ make
+	cp $(HOME)/rpmbuild/RPMS/$(TARGET_ARCH)/$(notdir $@) $@
+	$(SUDO) rpm -ivh $@
+
+myperl-crypt-ecdh: myperl-crypt-ecdh-$(OXI_VERSION)-1.$(TARGET_ARCH).rpm
+
+myperl-crypt-ecdh-$(OXI_VERSION)-1.$(TARGET_ARCH).rpm: $(DEP.CRYPT_ECDH.GITDIR)
+	for i in $(OPENXPKI.GITDIR)/.VERSION_*; do \
+		cd $(CONFIG.GITDIR)/package/suse/myperl-crypt-ecdh && ln -sf $$i;\
+	done
+	cd $(CONFIG.GITDIR)/package/suse/myperl-crypt-ecdh \
+		&& PERL5LIB=\$$HOME/perl5/lib/perl5/ make
+
+

--- a/vagrant/opensuse/manual-cpan-mods.txt
+++ b/vagrant/opensuse/manual-cpan-mods.txt
@@ -1,0 +1,15 @@
+indirect
+bareword::filehandles
+multidimensional
+Inline::C
+FCGI
+Net::SSL
+Net::LDAP
+Net::Server
+Variable::Magic
+Class::Accessor::Chained::Fast
+Text::CSV_XS
+SOAP::Lite
+JSON
+IO::Prompt
+Crypt::PKCS10

--- a/vagrant/opensuse/pinto.mk
+++ b/vagrant/opensuse/pinto.mk
@@ -1,0 +1,42 @@
+# Pinto is used to manage a local CPAN Mirror.
+#
+# TARGETS:
+#
+# prereqs		Install Pinto from CPAN
+#
+
+PINTO_REPOSITORY_ROOT := $(HOME)/pinto
+
+info:
+	@echo "Pinto root = $(PINTO_REPOSITORY_ROOT)"
+	@pinto -r $(PINTO_REPOSITORY_ROOT) list
+
+prereqs:
+	# need --notest because of http_proxy
+	cpanm --notest App::Pinto
+
+init: $(PINTO_REPOSITORY_ROOT)
+
+load: load-openxpki-core load-misc
+
+$(PINTO_REPOSITORY_ROOT):
+	pinto -r $(PINTO_REPOSITORY_ROOT) init
+	pinto -r $(PINTO_REPOSITORY_ROOT) copy master oxibld
+
+openxpki-core.deps:
+	(cd ~/git/openxpki/core/server && cpanm --scandeps .) \
+		| grep 'Found dependencies' \
+		| perl -pe 's/.+dependencies: //' > $@.new
+	mv $@.new $@
+
+load-openxpki-core: openxpki-core.deps
+	cat $< | xargs pinto -r $(PINTO_REPOSITORY_ROOT) \
+		pull --recurse --stack oxibld \
+		--cascade --message "import oxi core"
+		
+load-misc: manual-cpan-mods.txt
+	cat $< | xargs pinto -r $(PINTO_REPOSITORY_ROOT) \
+		pull --recurse --stack oxibld --cascade \
+		--message "import oxi misc"
+
+


### PR DESCRIPTION
Since Module::Build should do the right thing (tm) when installing
scripts, it seems that using /usr/bin/env brings more trouble
than it's worth.