### PR TITLE
Revert shebang from using /usr/bin/env

### DIFF
--- a/clients/perl/OpenXPKI-Client-Enrollment/script/enroller
+++ b/clients/perl/OpenXPKI-Client-Enrollment/script/enroller
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/clients/perl/OpenXPKI-Client-Enrollment/script/sscep-wrapper
+++ b/clients/perl/OpenXPKI-Client-Enrollment/script/sscep-wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/clients/perl/OpenXPKI-Client-Enrollment/t/mock-scep-server
+++ b/clients/perl/OpenXPKI-Client-Enrollment/t/mock-scep-server
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 use Mojolicious::Lite;
 
 use lib ('lib', '../../../qatest/lib');

--- a/clients/perl/OpenXPKI-Client-Enrollment/t/sscep-mock
+++ b/clients/perl/OpenXPKI-Client-Enrollment/t/sscep-mock
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/i18n/build-pot.pl
+++ b/core/i18n/build-pot.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/bin/openxpkiadm
+++ b/core/server/bin/openxpkiadm
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/bin/openxpkicli
+++ b/core/server/bin/openxpkicli
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # Written by Oliver Welter
 # for the OpenXPKI project 2013

--- a/core/server/bin/openxpkicmd
+++ b/core/server/bin/openxpkicmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # Written by Martin Bartosch
 # extended by Oliver Welter

--- a/core/server/bin/openxpkictl
+++ b/core/server/bin/openxpkictl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/cgi-bin/scep
+++ b/core/server/cgi-bin/scep
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 ## CGI script for the OpenXPKI SCEP server
 ##
 ## Written by Oliver Welter OpenXPKI Project

--- a/core/server/cgi-bin/webui-mock.cgi
+++ b/core/server/cgi-bin/webui-mock.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/core/server/cgi-bin/webui.cgi
+++ b/core/server/cgi-bin/webui.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use CGI;
 use CGI::Session;

--- a/core/server/cgi-bin/webui.fcgi
+++ b/core/server/cgi-bin/webui.fcgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use CGI;
 use CGI::Fast;

--- a/package/suse/cpan/cpandeps.pl
+++ b/package/suse/cpan/cpandeps.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # cpandeps.pl - Create include files for makefiles to set CPAN dependencies
 #

--- a/qatest/t/certhelper.t
+++ b/qatest/t/certhelper.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/automated_test_reports/generate_report.pl
+++ b/tools/automated_test_reports/generate_report.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/automated_test_reports/run_test.pl
+++ b/tools/automated_test_reports/run_test.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/automated_test_reports/update_svn_and_test.pl
+++ b/tools/automated_test_reports/update_svn_and_test.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 use strict;
 use warnings;

--- a/tools/scripts/ogflow.pl
+++ b/tools/scripts/ogflow.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/perl -w
 #
 # ogflow.pl - Convert OmniGraffle File to Workflow Definition
 #

--- a/tools/vergen
+++ b/tools/vergen
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 #
 # Written by Martin Bartosch for the OpenXPKI project 2006
 # Copyright (c) 2006-2011 by The OpenXPKI Project


### PR DESCRIPTION
Since Module::Build should do the right thing (tm) when installing
scripts, it seems that using /usr/bin/env brings more trouble
than it's worth.