### PR TITLE
Fixed rtd_theme finding

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,8 +94,12 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 # html_theme = 'default'
 
-html_theme = "sphinx_rtd_theme"
-html_theme_path = ["_themes", ]
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = ["_themes", sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
According to https://github.com/choderalab/pymbar/commit/56ff6b04049a6dd4130b78742c45c6bd0c8de84d this is the 'correct' way to include and use the rtd theme. Works for me on three different machines (Fedora 22, Suse 42.1, Debian Sid) with system side installed rtd theme.