### PR TITLE
Revert erroneously (?) changes to default log config

### DIFF
--- a/config/openxpki/log.conf
+++ b/config/openxpki/log.conf
@@ -34,7 +34,7 @@ log4perl.category.openxpki.system = INFO, Logfile
 ## FACILITY: WORKFLOW
 # INTERNAL logger for the workflow engine, conditions evaluated, actions taken
 # This must not be used by implementors, log your stuff to APPLICATION!
-log4perl.category.openxpki.workflow = DEBUG, WorkflowLog
+log4perl.category.openxpki.workflow = INFO, WorkflowLog
 
 ## FACILITY: APPLICATION
 # info about the workflows, conditions evaluated, actions taken

--- a/config/openxpki/log.conf
+++ b/config/openxpki/log.conf
@@ -42,14 +42,13 @@ log4perl.category.openxpki.application = INFO, Logfile, DBI
 
 ## FACILITY: USAGE
 # Poor-Mans statistcs tool to track usage of functions
-# the log message should be a single token 
+# the log message should be a single token
 log4perl.category.openxpki.usage = INFO, DBI
 
 
 ## FACILITY: Connector (outside OXI!)
 # internal logging of the config layer, errors indicate missconfiguration
-#log4perl.category.connector = ERROR, Connector
-log4perl.category.connector = DEBUG, Connector
+log4perl.category.connector = ERROR, Connector
 
 ## Appenders are the modules which do the real work. Different
 ## facilities/loggers can use the same appenders.


### PR DESCRIPTION
Commit b42662caac32522eeeba7ee13c76396e745d6e74 changed the default log level of Log4Perl category "connector" to "DEBUG" which causes a lot of noise.