### PR TITLE
Fix "search_cert" API method (closes #501)

### DIFF
--- a/core/server/OpenXPKI/Server/API/Object.pm
+++ b/core/server/OpenXPKI/Server/API/Object.pm
@@ -1063,7 +1063,7 @@ sub __search_cert_db_query {
             my $table_alias = "certattr$ii";
 
             # add join table
-            push @join_spec, ( 'identifier=identifier', "certificate_attributes|$table_alias" );
+            push @join_spec, ( 'certificate.identifier=identifier', "certificate_attributes|$table_alias" );
 
             # add search constraint
             $where->{ "$table_alias.attribute_contentkey" } = $attrib->{KEY};
@@ -1083,7 +1083,7 @@ sub __search_cert_db_query {
     }
 
     if ( $args->{PROFILE} ) {
-        push @join_spec, qw( req_key=req_key csr );
+        push @join_spec, qw( certificate.req_key=req_key csr );
         $where->{ 'csr.profile' } = $args->{PROFILE};
     }
 


### PR DESCRIPTION
"search_cert" failed with an exception when searching for attributes AND
profile.

The reason was that __search_cert_db_query() created a wrong SQL query
when multiple SQL JOINs where involved.