### PR TITLE
Activate purging of expired sessions but without COMMIT

### DIFF
--- a/core/server/OpenXPKI/Server/Session.pm
+++ b/core/server/OpenXPKI/Server/Session.pm
@@ -156,6 +156,12 @@ around BUILDARGS => sub {
     return $class->$orig(%args);
 };
 
+=head1 STATIC METHODS
+
+=head2 new
+
+Constructor that creates a new session with an empty data object.
+
 =head1 METHODS
 
 =cut

--- a/core/server/OpenXPKI/Server/Session/Driver/Database.pm
+++ b/core/server/OpenXPKI/Server/Session/Driver/Database.pm
@@ -10,13 +10,13 @@ persists to the database
 
 =head1 SYNOPSIS
 
-To use the global database handle:
+To use the global database handle (C<CTX('dbi')>:
 
     my $session = OpenXPKI::Server::Session->new(
         type => "Database",
     );
 
-To specify a different database:
+To specify a different database (i.e. use a separate database handle):
 
     my $session = OpenXPKI::Server::Session->new(
         type => "Database",
@@ -27,6 +27,14 @@ To specify a different database:
     );
 
 =head1 DESCRIPTION
+
+The methods in this class do not execute C<COMMIT>s on the database if it's
+configured to reuse the global database handle. This is to make sure
+transcations started in the core application logic are not disturbed.
+
+If an own database handle is created, it's configured to do C<AUTOCOMMIT>s.
+
+=head1 METHODS
 
 Please see L<OpenXPKI::Server::Session::DriverRole> for a description of the
 available methods.
@@ -165,7 +173,7 @@ sub delete {
 sub delete_all_before {
     my ($self, $epoch) = @_;
     ##! 8: "deleting all sessions where modified < $epoch"
-    return $self->dbi->delete_and_commit(
+    return $self->dbi->delete(
         from => $self->table,
         where => {
             modified => { '<' => $epoch },

--- a/core/server/OpenXPKI/Server/Session/DriverRole.pm
+++ b/core/server/OpenXPKI/Server/Session/DriverRole.pm
@@ -93,12 +93,6 @@ B<Parameters>
 
 =back
 
-=head1 STATIC METHODS
-
-=head2 new
-
-Constructor that creates a new session with an empty data object.
-
 =cut
 
 1;

--- a/core/server/OpenXPKI/Service/Default.pm
+++ b/core/server/OpenXPKI/Service/Default.pm
@@ -655,7 +655,7 @@ sub __handle_STATUS : PRIVATE {
         my $param = shift;
         return CTX('session')->data->$param if OpenXPKI::Server::Context::hascontext('session');
         return undef;
-    }
+    };
     # SERVICE_MSG ?
     return {
         SESSION => {
@@ -776,7 +776,7 @@ sub __pki_realm_choice_available : PRIVATE {
 
     ##! 2: "check if PKI realm is already known"
     my $realm = OpenXPKI::Server::Context::hascontext('session')
-        ? CTX('session')->data->pki_realm;
+        ? CTX('session')->data->pki_realm
         : undef;
     return $realm if defined $realm;
 

--- a/core/server/OpenXPKI/Service/Default.pm
+++ b/core/server/OpenXPKI/Service/Default.pm
@@ -215,6 +215,10 @@ sub __handle_NEW_SESSION : PRIVATE {
     ##! 4: "new session"
     my $session = OpenXPKI::Server::Session->new(load_config => 1)->create;
 
+    # purge expired sessions
+    # (it's ok to do this unregularly as expired sessions will always be rejected)
+    $session->purge_expired;
+
     if (exists $msg->{LANGUAGE}) {
         ##! 8: "set language"
         set_language($msg->{LANGUAGE});


### PR DESCRIPTION
A COMMIT might disturb other transactions in cases where the database session driver is configured to reuse the global database handle.