### PR TITLE
Change log level to TRACE if Dumper() is used

### DIFF
--- a/core/server/OpenXPKI/Client/SC.pm
+++ b/core/server/OpenXPKI/Client/SC.pm
@@ -29,7 +29,7 @@ sub handle_request {
     }
 
     my $log = $self->logger();
-    $log->debug("Loading handler class $class, method $method, extra params " . Dumper \%extra );
+    $log->trace("Loading handler class $class, method $method, extra params " . Dumper \%extra );
 
     $class = 'OpenXPKI::Client::SC::'.ucfirst($class);
     $method = 'handle_' . $method;

--- a/core/server/OpenXPKI/Client/SC/Personalization.pm
+++ b/core/server/OpenXPKI/Client/SC/Personalization.pm
@@ -188,10 +188,11 @@ sub handle_server_personalization {
                 'login_ids' => $self->serializer()->serialize( [ $user ] )
             }
         };
-        
-        $log->debug('Execute select_useraccount with params ' . Dumper $params );
-        
-        eval {    
+
+        $log->debug('Execute select_useraccount');
+        $log->trace('Parameters: ' . Dumper $params );
+
+        eval {
             $wf_info = $self->_client->handle_workflow( $params );
         };
         if ($EVAL_ERROR) {

--- a/core/server/OpenXPKI/Client/SC/Result.pm
+++ b/core/server/OpenXPKI/Client/SC/Result.pm
@@ -122,7 +122,7 @@ sub _init_carddata {
     my $cardData = {};
     if ($session->param('cardData')) {
         $cardData = $session->param('cardData');
-        $self->logger()->debug('Restore card data from session: ' . Dumper $cardData); 
+        $self->logger()->trace('Restore card data from session: ' . Dumper $cardData);
     }
 
     if ( ! defined $cardID ) {
@@ -163,9 +163,9 @@ sub _init_carddata {
     if ($ChipSerial) {
         $cardData->{'ChipSerial'} = $ChipSerial;
     }
-    
-    $self->logger()->debug('Card Data ' . Dumper $cardData);
-    
+
+    $self->logger()->trace('Card Data ' . Dumper $cardData);
+
     $session->param('cardData', $cardData );
 
     return $cardData;

--- a/core/server/OpenXPKI/Client/SC/Utilities.pm
+++ b/core/server/OpenXPKI/Client/SC/Utilities.pm
@@ -47,9 +47,9 @@ sub handle_get_server_status {
     if ($result->{get_server_status} ne 'OK') {
         $self->logger()->warn( "Server Status is : " . $result->{get_server_status} );
     }
-     
-    $self->logger()->debug( "Server Status " . Dumper $result );
-           
+
+    $self->logger()->trace( "Server Status " . Dumper $result );
+
     $self->_result($result);
 
     return 0;
@@ -100,9 +100,9 @@ sub handle_get_card_status {
     $log->info('Request for card status for cardID ' .  $cardData->{'cardID'} );
 
     my $p = $self->param();
-    $log->debug('Request params ' . Dumper $p );
-    
-    # Load the certificates from the request 
+    $log->trace('Request params ' . Dumper $p );
+
+    # Load the certificates from the request
     my @certs;
 
     my $wf_type_unblock = $config->{workflow}->{pinunblock};
@@ -151,7 +151,8 @@ sub handle_get_card_status {
 
     my @workflows;
 
-    $log->debug( 'sc_analyse reply ' . Dumper $reply );
+    $log->trace( 'sc_analyse reply ' . Dumper $reply );
+
 
 
     if ( scalar @{$reply->{WORKFLOWS}->{ $wf_type_unblock }} ) {
@@ -186,7 +187,7 @@ sub handle_get_card_status {
 
         my $wf_info = $self->_client()->handle_workflow({ 'ID' => $newentry{'WORKFLOW_SERIAL'} });
 
-        $log->debug( 'user workflow ' . Dumper $wf_info );
+        $log->trace( 'user workflow ' . Dumper $wf_info );
 
         if ($wf_info->{'TYPE'} eq $wf_type_unblock) {
             $newentry{'auth1_ldap_mail'} = $wf_info->{CONTEXT}->{auth1_mail};
@@ -196,7 +197,7 @@ sub handle_get_card_status {
             $newentry{'TOKEN_ID'} = $wf_info->{CONTEXT}->{token_id};
         }
 
-        $log->debug( 'Workflow Item after process ' . Dumper \%newentry ); 
+        $log->trace( 'Workflow Item after process ' . Dumper \%newentry );
         push @mangled_workflows, \%newentry;
     }
 

--- a/core/server/OpenXPKI/Client/Session/Driver.pm
+++ b/core/server/OpenXPKI/Client/Session/Driver.pm
@@ -45,7 +45,7 @@ sub store {
         SESSION_DATA => $datastr,
     });
 
-    $self->logger()->debug('Session store result ' . Dumper $res);
+    $self->logger()->trace('Session store result ' . Dumper $res);
 
 }
 
@@ -54,7 +54,7 @@ sub retrieve {
     my ($self, $sid) = @_;
 
     my $res = $self->backend()->send_receive_service_msg('FRONTEND_SESSION');
-    $self->logger()->debug('Session retrieve ' . Dumper $res);
+    $self->logger()->trace('Session retrieve ' . Dumper $res);
     return $res->{SESSION_DATA} || '';
 
 

--- a/core/server/OpenXPKI/Client/Simple.pm
+++ b/core/server/OpenXPKI/Client/Simple.pm
@@ -122,7 +122,7 @@ sub _build_client {
         my $realm = $self->_config()->{'realm'};
         if (! $realm ) {
             $log->fatal("Found more than one realm but no realm is specified");
-            $log->debug("Realms found:" . Dumper (keys %{$reply->{PARAMS}->{PKI_REALMS}}));
+            $log->trace("Realms found:" . Dumper (keys %{$reply->{PARAMS}->{PKI_REALMS}}));
             die "No realm specified";
         }
         $log->debug("Selecting realm $realm");
@@ -134,7 +134,7 @@ sub _build_client {
         my $auth = $self->auth();
         if (! $auth || !$auth->{stack}) {
             $log->fatal("Found more than one auth stack but no stack is specified");
-            $log->debug("Stacks found:" . Dumper (keys %{$reply->{PARAMS}->{AUTHENTICATION_STACKS}}));
+            $log->trace("Stacks found:" . Dumper (keys %{$reply->{PARAMS}->{AUTHENTICATION_STACKS}}));
             die "No auth stack specified";
         }
         $log->debug("Selecting auth stack ". $auth->{stack});
@@ -158,7 +158,7 @@ sub _build_client {
 
     if ($reply->{SERVICE_MSG} ne 'SERVICE_READY') {
         $log->fatal("Initialization failed - message is " . $reply->{SERVICE_MSG});
-        $log->debug('Last reply: ' .Dumper $reply);
+        $log->trace('Last reply: ' .Dumper $reply);
         die "Initialization failed. Stopped";
     }
     return $client;
@@ -189,7 +189,7 @@ sub run_command {
             $message = 'unknown error';
         }
         $self->logger()->error($message);
-        $self->logger()->debug(Dumper $reply);
+        $self->logger()->trace(Dumper $reply);
         $self->last_error($message);
         die "Error running command: $message";
     }
@@ -244,7 +244,7 @@ sub handle_workflow {
     if ($params->{ACTIVITY} && $params->{ID}) {
 
         $self->logger()->info(sprintf('execute workflow action %s on %01d', $params->{ACTIVITY}, $params->{ID}));
-        $self->logger()->debug('workflow params:  '. Dumper $params->{PARAMS});
+        $self->logger()->trace('workflow params:  '. Dumper $params->{PARAMS});
         $reply = $self->run_command('execute_workflow_activity',{
             ID => $params->{ID},
             ACTIVITY => $params->{ACTIVITY},
@@ -292,7 +292,7 @@ sub handle_workflow {
         die "Neither workflow id nor type given";
     }
 
-    $self->logger()->debug('Result of workflow action: ' . Dumper $reply);
+    $self->logger()->trace('Result of workflow action: ' . Dumper $reply);
 
     return $reply->{WORKFLOW};
 }

--- a/core/server/OpenXPKI/Client/UI.pm
+++ b/core/server/OpenXPKI/Client/UI.pm
@@ -234,7 +234,7 @@ sub __load_class {
     my %extra;
     if ($param) {
         %extra = split /!/, $param;
-        $self->logger()->debug("Found extra params " . Dumper \%extra );
+        $self->logger()->trace("Found extra params " . Dumper \%extra );
     }
 
     $self->logger()->debug("Loading handler class $class");
@@ -576,7 +576,7 @@ sub handle_login {
             # Check for MOTD
             my $motd = $self->backend()->send_receive_command_msg( 'get_motd' );
             if (ref $motd->{PARAMS} eq 'HASH') {
-                $self->logger()->debug('Got MOTD: '. Dumper $motd->{PARAMS} );
+                $self->logger()->trace('Got MOTD: '. Dumper $motd->{PARAMS} );
                 $self->session()->param('motd', $motd->{PARAMS} );
             }
 
@@ -585,8 +585,8 @@ sub handle_login {
                 push @main::header, ('-cookie', $cgi->cookie( $main::cookie ));
             }
 
-            $self->logger()->debug('Got session info: '. Dumper $reply->{PARAMS});
-            $self->logger()->debug('CGI Header ' . Dumper \@main::header );
+            $self->logger()->trace('Got session info: '. Dumper $reply->{PARAMS});
+            $self->logger()->trace('CGI Header ' . Dumper \@main::header );
 
             $result->init_index();
             return $result->render();
@@ -595,7 +595,7 @@ sub handle_login {
 
     if ( $reply->{SERVICE_MSG} eq 'ERROR') {
 
-        $self->logger()->debug('Server Error Msg: '. Dumper $reply);
+        $self->logger()->trace('Server Error Msg: '. Dumper $reply);
 
         # Failure here is likely a wrong password
         if ($reply->{'LIST'} && $reply->{'LIST'}->[0]->{LABEL} eq 'I18N_OPENXPKI_SERVER_AUTHENTICATION_LOGIN_FAILED') {

--- a/core/server/OpenXPKI/Client/UI/Bootstrap.pm
+++ b/core/server/OpenXPKI/Client/UI/Bootstrap.pm
@@ -29,18 +29,18 @@ sub init_structure {
         $self->logger()->trace('Menu ' . Dumper $menu);
 
         $self->_result()->{structure} = $menu->{main};
-        
+
         # persist the optional parts of the menu hash (landmark, tasklist, search attribs)
         $session->param('landmark', $menu->{landmark} || {});
-        $self->logger->debug('Got landmarks: ' . Dumper $menu->{landmark});
-        
+        $self->logger->trace('Got landmarks: ' . Dumper $menu->{landmark});
+
         # tasklist, wfsearch, certsearch and bulk can have multiple branches
         # using named keys. We try to autodetect legacy formats and map
         # those to a "default" key
-        
+
         # config items are a list of hashes
         foreach my $key (qw(tasklist bulk)) {
-            
+
             if (ref $menu->{$key} eq 'ARRAY') {
                 $session->param($key, { 'default' => $menu->{$key} });
             } elsif (ref $menu->{$key} eq 'HASH') {
@@ -48,13 +48,13 @@ sub init_structure {
             } else {
                 $session->param($key, { 'default' => [] });
             }
-            $self->logger->debug("Got $key: " . Dumper $menu->{$key});    
+            $self->logger->trace("Got $key: " . Dumper $menu->{$key});
         }
-       
+
         # top level is a hash that must have a "attributes" node
-        # legacy format was a single list of attributes 
+        # legacy format was a single list of attributes
         foreach my $key (qw(wfsearch certsearch)) {
-            
+
             # plain attributes
             if (ref $menu->{$key} eq 'ARRAY') {
                 $session->param($key, { 'default' => { attributes => $menu->{$key} } } );
@@ -63,29 +63,29 @@ sub init_structure {
             } else {
                 $session->param($key, { 'default' => {} });
             }
-            $self->logger->debug("Got $key: " . Dumper $menu->{$key});    
+            $self->logger->trace("Got $key: " . Dumper $menu->{$key});
         }
-        
+
         if ($menu->{ping}) {
             my $ping;
             if (ref $menu->{ping} eq 'HASH') {
                 $ping = $menu->{ping};
-                $ping->{timeout} *= 1000; # timeout is expected in ms 
+                $ping->{timeout} *= 1000; # timeout is expected in ms
             } else {
                 $ping = { href => $menu->{ping}, timeout => 120000 };
             }
             $self->_result()->{ping} = $ping;
         }
-        
+
     }
-    
+
     # To issue redirects to the UI, we store the referrer
     # default is mainly relevant for test scripts
     my $baseurl = $self->param('baseurl') || '/openxpki';
     $baseurl =~ s|/$||;
     $session->param('baseurl',  $baseurl.'/#/');
     $self->logger->debug("Baseurl from referrer: " . $baseurl);
-    
+
     if (!$self->_result()->{structure}) {
         $self->_result()->{structure} =
         [{

--- a/core/server/OpenXPKI/Client/UI/Bulk.pm
+++ b/core/server/OpenXPKI/Client/UI/Bulk.pm
@@ -117,8 +117,8 @@ sub action_result {
 
     $query->{ATTRIBUTE} = \@attr;
 
-    $self->logger()->debug("query : " . Dumper $query);
-    
+    $self->logger()->trace("query : " . Dumper $query);
+
     my $result_count = $self->send_command( 'search_workflow_instances_count',  {
         'STATE' => $query->{STATE},
         'TYPE' => $query->{TYPE},

--- a/core/server/OpenXPKI/Client/UI/Certificate.pm
+++ b/core/server/OpenXPKI/Client/UI/Certificate.pm
@@ -184,14 +184,14 @@ sub init_result {
         }
     }
 
-    $self->logger()->debug( "persisted query: " . Dumper $result);
+    $self->logger()->trace( "persisted query: " . Dumper $result);
 
     my $search_result = $self->send_command( 'search_cert', $query );
-    
+
     $self->logger()->trace( "search result: " . Dumper $search_result);
 
     $self->_page({
-        label => 'I18N_OPENXPKI_UI_CERTIFICATE_SEARCH_RESULT_LABEL',       
+        label => 'I18N_OPENXPKI_UI_CERTIFICATE_SEARCH_RESULT_LABEL',
         description => 'I18N_OPENXPKI_UI_CERTIFICATE_SEARCH_RESULT_DESC',
     });
 
@@ -289,18 +289,18 @@ sub init_export {
         }
     }
 
-    $self->logger()->debug( "persisted query: " . Dumper $result);
+    $self->logger()->trace( "persisted query: " . Dumper $result);
 
     my $search_result = $self->send_command( 'search_cert', $query );
-    
+
     $self->logger()->trace( "search result: " . Dumper $search_result);
-    
+
     my $header = $result->{header};
     $header = $self->__default_grid_head() if(!$header);
 
     my @head;
     my @cols;
-    
+
     my $ii = 0;
     foreach my $col (@{$header}) {
         # skip hidden fields
@@ -396,8 +396,8 @@ sub init_pager {
         $query->{REVERSE} = $self->param('reverse');
     }
 
-    $self->logger()->debug( "persisted query: " . Dumper $result);
-    $self->logger()->debug( "executed query: " . Dumper $query);
+    $self->logger()->trace( "persisted query: " . Dumper $result);
+    $self->logger()->trace( "executed query: " . Dumper $query);
 
     my $search_result = $self->send_command( 'search_cert', $query );
 
@@ -445,7 +445,7 @@ sub init_mine {
         REVERSE => 1,
     };
 
-    $self->logger()->debug( "search query: " . Dumper $query);
+    $self->logger()->trace( "search query: " . Dumper $query);
 
     my $search_result = $self->send_command( 'search_cert', { %$query, ( LIMIT => $limit, START => $startat ) } );
 
@@ -542,17 +542,17 @@ sub init_detail {
                 ],
             }},
         );
-        
+
         return;
     }
-    
-    $self->logger()->debug("result: " . Dumper $cert);
-    
+
+    $self->logger()->trace("result: " . Dumper $cert);
+
     my $cert_attribute = $self->send_command( 'get_cert_attributes', {  IDENTIFIER => $cert_identifier, ATTRIBUTE => 'subject_%' });
-    $self->logger()->debug("result: " . Dumper $cert_attribute);
-            
+    $self->logger()->trace("result: " . Dumper $cert_attribute);
+
     my %dn = OpenXPKI::DN->new( $cert->{SUBJECT} )->get_hashed_content();
-    
+
     $self->_page({
         label => 'I18N_OPENXPKI_UI_CERTIFICATE_DETAIL_LABEL',
         shortlabel => $dn{CN}[0]
@@ -613,9 +613,9 @@ sub init_detail {
 
         my @actions;
         my $reply = $self->send_command ( "get_cert_actions", { IDENTIFIER => $cert_identifier });
-        
-        $self->logger()->debug("available actions for cert " . Dumper $reply);
-        
+
+        $self->logger()->trace("available actions for cert " . Dumper $reply);
+
         if (defined $reply->{workflow} && ref $reply->{workflow} eq 'ARRAY') {
             foreach my $item (@{$reply->{workflow}}) {
                 push @actions, { page => $baseurl.$item->{workflow}, label => $item->{label}, target => '_blank' };
@@ -645,28 +645,28 @@ sub init_detail {
 
 }
 
-=head2 init_text 
+=head2 init_text
 
 Show the PEM block as text in a modal
 
 =cut
 
 sub init_text {
-    
+
     my $self = shift;
     my $args = shift;
 
     my $cert_identifier = $self->param('identifier');
-    
+
     my $pem = $self->send_command ( "get_cert", {'IDENTIFIER' => $cert_identifier, 'FORMAT' => 'PEM' });
-    
-    $self->logger()->debug("Cert data: " . Dumper $pem);
-    
+
+    $self->logger()->trace("Cert data: " . Dumper $pem);
+
     $self->_page({
         label => 'I18N_OPENXPKI_UI_CERTIFICATE_DETAIL_LABEL',
         shortlabel => $cert_identifier,
     });
-    
+
     $self->add_section({
         type => 'text',
         content => {
@@ -748,10 +748,10 @@ sub init_related {
     my $cert_identifier = $self->param('identifier');
 
     my $cert = $self->send_command( 'get_cert', {  IDENTIFIER => $cert_identifier, FORMAT => 'DBINFO' });
-    $self->logger()->debug("result: " . Dumper $cert);
-    
+    $self->logger()->trace("result: " . Dumper $cert);
+
     my %dn = OpenXPKI::DN->new( $cert->{SUBJECT} )->get_hashed_content();
-    
+
     $self->_page({
         label => 'I18N_OPENXPKI_UI_CERTIFICATE_RELATIONS_LABEL',
         shortlabel => $dn{CN}[0]
@@ -765,9 +765,9 @@ sub init_related {
         }
         push @wfid, @{$cert->{CERT_ATTRIBUTES}->{$key}};
     }
-    
-    $self->logger()->debug("related workflows " . Dumper \@wfid);
-    
+
+    $self->logger()->trace("related workflows " . Dumper \@wfid);
+
     my $cert_workflows = $self->send_command( 'search_workflow_instances', {  SERIAL => \@wfid });
 
     $self->logger()->trace("workflow results" . Dumper $cert_workflows);
@@ -843,7 +843,7 @@ sub init_download {
     } elsif ($format eq 'bundle') {
 
         my $chain = $self->send_command ( "get_chain", { START_IDENTIFIER => $cert_identifier, OUTFORMAT => 'PEM', 'KEEPROOT' => 1 });
-        $self->logger()->debug("chain info " . Dumper $chain );
+        $self->logger()->trace("chain info " . Dumper $chain );
 
         my $cert_info  = $self->send_command ( "get_cert", {'IDENTIFIER' => $cert_identifier, 'FORMAT' => 'HASH' });
         my $filename = $cert_info->{BODY}->{SUBJECT_HASH}->{CN}->[0] || $cert_info->{BODY}->{IDENTIFIER};
@@ -861,7 +861,7 @@ sub init_download {
     } else {
 
         my $cert_info = $self->send_command ( "get_cert", {'IDENTIFIER' => $cert_identifier, 'FORMAT' => 'HASH' });
-        $self->logger()->debug("cert info " . Dumper $cert_info );
+        $self->logger()->trace("cert info " . Dumper $cert_info );
 
         my $content_type = 'application/octet-string';
         my $filename = $cert_info->{BODY}->{SUBJECT_HASH}->{CN}->[0] || $cert_info->{BODY}->{IDENTIFIER};
@@ -948,7 +948,7 @@ sub action_autocomplete {
 
     my $term = $self->param('query') || '';
 
-    $self->logger()->debug( "autocomplete term: " . Dumper $term);
+    $self->logger()->trace( "autocomplete term: " . Dumper $term);
 
     my @result;
     # If we see a string with length of 25 to 27 with only base64 chars
@@ -990,8 +990,8 @@ sub action_autocomplete {
             };
         }
     }
-    
-    $self->logger()->debug( "search result: " . Dumper \@result);
+
+    $self->logger()->trace( "search result: " . Dumper \@result);
 
     $self->_result()->{_raw} = \@result;
 
@@ -1090,7 +1090,7 @@ sub action_search {
         $query->{STATUS} = $status;
     }
 
-    $self->logger()->debug("query : " . Dumper $self->cgi()->param());
+    $self->logger()->trace("query : " . Dumper $self->cgi()->param());
 
     # Read the query pattern for extra attributes from the session
     my $spec = $self->_client->session()->param('certsearch')->{default};
@@ -1110,7 +1110,7 @@ sub action_search {
         $query->{CERT_ATTRIBUTES} = \@attr;
     }
 
-    $self->logger()->debug("query : " . Dumper $query);
+    $self->logger()->trace("query : " . Dumper $query);
 
 
     my $result_count = $self->send_command( 'search_cert_count', $query );

--- a/core/server/OpenXPKI/Client/UI/Crl.pm
+++ b/core/server/OpenXPKI/Client/UI/Crl.pm
@@ -30,7 +30,7 @@ sub init_index {
     my $empty = 1;
     foreach my $issuer (@$issuers) {
 
-        $self->logger()->debug("Issuer: " . Dumper $issuer);
+        $self->logger()->trace("Issuer: " . Dumper $issuer);
 
         my $crl_list = $self->send_command( 'get_crl_list' , {
             FORMAT => 'HASH',
@@ -40,7 +40,7 @@ sub init_index {
         });
 
         my $crl_hash = $crl_list->[0];
-        $self->logger()->debug("result: " . Dumper $crl_list);
+        $self->logger()->trace("result: " . Dumper $crl_list);
 
         if (!@$crl_list) {
 
@@ -90,7 +90,7 @@ sub init_list {
         ISSUER => $self->param('issuer')
     });
 
-    $self->logger()->debug("result: " . Dumper $crl_list);
+    $self->logger()->trace("result: " . Dumper $crl_list);
 
     $self->_page({
         label => 'I18N_OPENXPKI_UI_CRL_LIST_FOR_ISSUER ' . $self->_escape($crl_list->[0]->{BODY}->{'ISSUER'}),
@@ -147,7 +147,7 @@ sub init_detail {
         CRL_KEY => $crl_key,
         FORMAT => 'HASH'
     });
-    $self->logger()->debug("result: " . Dumper $crl_hash);
+    $self->logger()->trace("result: " . Dumper $crl_hash);
 
     $self->_page({
         label => 'I18N_OPENXPKI_UI_CRL_LIST_VIEW_DETAIL #' . $crl_hash->{SERIAL},

--- a/core/server/OpenXPKI/Client/UI/Handle/Profile.pm
+++ b/core/server/OpenXPKI/Client/UI/Handle/Profile.pm
@@ -14,7 +14,7 @@ sub render_profile_select {
     my $wf_action = shift;
 
 
-    $self->logger()->debug( 'render_profile_select with args: ' . Dumper $args );
+    $self->logger()->trace( 'render_profile_select with args: ' . Dumper $args );
 
     my $wf_info = $args->{WF_INFO};
 
@@ -110,7 +110,7 @@ sub render_subject_form {
     my $fields = $self->send_command( 'get_field_definition',
         { PROFILE => $cert_profile, STYLE => $cert_subject_style, 'SECTION' =>  substr($field_type, 5) });
 
-    $self->logger()->debug( 'Profile fields' . Dumper $fields );
+    $self->logger()->trace( 'Profile fields' . Dumper $fields );
 
     # Load preexisiting values from context
     my $values = {};
@@ -118,12 +118,12 @@ sub render_subject_form {
         $values = $self->serializer()->deserialize( $context->{$field_name} );
     }
 
-    $self->logger()->debug( 'Preset ' . Dumper $values );
+    $self->logger()->trace( 'Preset ' . Dumper $values );
 
     # Map the old notation for the new UI
     $fields = OpenXPKI::Client::UI::Handle::Profile::__translate_form_def( $fields, $field_name, $values );
 
-    $self->logger()->debug( 'Mapped fields' . Dumper $fields );
+    $self->logger()->trace( 'Mapped fields' . Dumper $fields );
 
     # record the workflow info in the session
     push @{$fields}, $self->__register_wf_token($wf_info, {
@@ -152,7 +152,7 @@ sub render_key_select {
     my $args = shift;
     my $wf_action = shift;
 
-    $self->logger()->debug( 'render_profile_select with args: ' . Dumper $args );
+    $self->logger()->trace( 'render_profile_select with args: ' . Dumper $args );
 
     my $wf_info = $args->{WF_INFO};
     my $context = $wf_info->{WORKFLOW}->{CONTEXT};
@@ -237,7 +237,7 @@ sub render_server_password {
     my $args = shift;
     my $wf_action = shift;
 
-    $self->logger()->debug( 'render_server_password with args: ' . Dumper $args );
+    $self->logger()->trace( 'render_server_password with args: ' . Dumper $args );
 
     my $wf_info = $args->{WF_INFO};
     my $context = $wf_info->{WORKFLOW}->{CONTEXT};

--- a/core/server/OpenXPKI/Client/UI/Handle/Report.pm
+++ b/core/server/OpenXPKI/Client/UI/Handle/Report.pm
@@ -12,13 +12,13 @@ sub render_report_list {
 
     my $wf_info = $args->{WF_INFO}->{WORKFLOW};
 
-    $self->logger()->debug( 'render_report_list: ' . Dumper $wf_info );
+    $self->logger()->trace( 'render_report_list: ' . Dumper $wf_info );
 
     $self->_page({
         label => $wf_info->{label},
         description => $wf_info->{description},
     });
-    
+
     my @data = @{$wf_info->{CONTEXT}->{report_list}};
     my @source;
     my $i=0;

--- a/core/server/OpenXPKI/Client/UI/Handle/Status.pm
+++ b/core/server/OpenXPKI/Client/UI/Handle/Status.pm
@@ -13,12 +13,12 @@ sub render_process_status {
     my $args = shift;
     my $wf_action = shift;
 
-    $self->logger()->debug( 'render_process_status: ' . Dumper $args );
+    $self->logger()->trace( 'render_process_status: ' . Dumper $args );
 
-    
+
     my $process = $self->send_command( 'list_process' );
 
-    $self->logger()->debug("result: " . Dumper $process );
+    $self->logger()->trace("result: " . Dumper $process );
 
     $self->_page({
         label => 'Running processes (global)',
@@ -155,16 +155,16 @@ sub render_system_status {
     # we fetch the list of tokens to display from the context
     # this allows a user to configure this
     my @token = split /\s*,\s*/, $wf_info->{WORKFLOW}->{CONTEXT}->{token};
-    
-    $self->logger()->debug("context: " . Dumper $wf_info->{WORKFLOW}->{CONTEXT} );
-    
-   
+
+    $self->logger()->trace("context: " . Dumper $wf_info->{WORKFLOW}->{CONTEXT} );
+
+
     foreach my $type (@token) {
 
         my $token = $self->send_command( 'list_active_aliases', { TYPE => $type, CHECK_ONLINE => 1 } );
 
-        $self->logger()->debug("result: " . Dumper $token );
-       
+        $self->logger()->trace("result: " . Dumper $token );
+
         my @result;
         foreach my $alias (@{$token}) {
 

--- a/core/server/OpenXPKI/Client/UI/Information.pm
+++ b/core/server/OpenXPKI/Client/UI/Information.pm
@@ -44,7 +44,7 @@ sub init_issuer {
     my $args = shift;
 
     my $issuers = $self->send_command( 'get_ca_list' );
-    $self->logger()->debug("result: " . Dumper $issuers);
+    $self->logger()->trace("result: " . Dumper $issuers);
 
     $self->_page({
         label => 'Issuing certificates of this Realm',

--- a/core/server/OpenXPKI/Client/UI/Profile.pm
+++ b/core/server/OpenXPKI/Client/UI/Profile.pm
@@ -15,7 +15,7 @@ sub action_get_styles_for_profile {
     my $self = shift;
     my $args = shift;
 
-    $self->logger()->debug( 'get_styles_for_profile with args: ' . Dumper $args );
+    $self->logger()->trace( 'get_styles_for_profile with args: ' . Dumper $args );
 
     my $cert_profile = $self->param('cert_profile');
     my $styles = $self->send_command( 'get_cert_subject_profiles', { PROFILE => $cert_profile });
@@ -62,7 +62,7 @@ sub action_get_key_param {
     # Get the possible parameters for this algo
     my $key_gen_param_supported = $key_alg ? $self->send_command( 'get_key_params', { PROFILE => $token->{cert_profile}, ALG => $key_alg }) : {};
 
-    $self->logger()->debug( '$key_gen_param_supported: ' . Dumper $key_gen_param_supported );
+    $self->logger()->trace( '$key_gen_param_supported: ' . Dumper $key_gen_param_supported );
 
     # The field names used in the ui are in the request
     my $in = $self->param();
@@ -77,7 +77,7 @@ sub action_get_key_param {
 
             my $preset = $key_gen_params->{$pn};
 
-            $self->logger()->debug( 'Preset '.$preset. ' Values ' . Dumper $key_gen_param_supported->{$param_name});
+            $self->logger()->trace( 'Preset '.$preset. ' Values ' . Dumper $key_gen_param_supported->{$param_name});
 
             if (!(grep $preset,  @{$key_gen_param_supported->{$param_name}})) {
                 $preset = $param[0]->{value};

--- a/core/server/OpenXPKI/Client/UI/Result.pm
+++ b/core/server/OpenXPKI/Client/UI/Result.pm
@@ -183,10 +183,10 @@ sub send_command {
             my @fields = (ref $field_errors eq 'ARRAY') ? map { $_->{name} } @$field_errors : ();
             $self->_status({ level => 'error', message => $validator_msg, field_errors => $field_errors });
             $self->logger()->error("Input validation error on fields ". join ",", @fields);
-            $self->logger()->debug('validation details' . Dumper $field_errors );
+            $self->logger()->trace('validation details' . Dumper $field_errors );
         } elsif (!$nostatus) {
             $self->logger()->error("command $command failed ($reply->{SERVICE_MSG})");
-            $self->logger()->debug("command reply ". Dumper $reply);
+            $self->logger()->trace("command reply ". Dumper $reply);
             $self->set_status_from_error_reply( $reply );
         }
         return undef;
@@ -461,7 +461,7 @@ sub init_fetch {
         return $self;
     }
 
-    $self->logger()->debug('Got response ' . Dumper $data);
+    $self->logger()->trace('Got response ' . Dumper $data);
 
     # support multi-valued responses (persisted as array ref)
     if (ref $data eq 'ARRAY') {
@@ -740,7 +740,7 @@ sub __render_pager {
         $args->{pagersize} = 20;
     }
 
-    $self->logger()->debug('pager query' . Dumper $args);
+    $self->logger()->trace('pager query' . Dumper $args);
 
     return {
         startat => $startat,

--- a/core/server/OpenXPKI/Client/UI/Secret.pm
+++ b/core/server/OpenXPKI/Client/UI/Secret.pm
@@ -125,7 +125,7 @@ sub action_unlock {
         { SECRET => $secret, VALUE => $phrase });
 
    $self->logger()->info('Secret was send');
-   $self->logger()->debug('Return ' . Dumper $msg);
+   $self->logger()->trace('Return ' . Dumper $msg);
 
     if ($msg) {
         $self->set_status('Secret accepted','success');

--- a/core/server/OpenXPKI/Client/UI/Source.pm
+++ b/core/server/OpenXPKI/Client/UI/Source.pm
@@ -99,7 +99,7 @@ sub _init_path {
 
     my $config = $self->_client()->_config();
 
-    $self->logger()->debug('Got config ' . Dumper $config);
+    $self->logger()->trace('Got config ' . Dumper $config);
 
     if ($config->{staticdir}) {
         if (! -d $config->{staticdir}) {

--- a/core/server/OpenXPKI/Client/UI/Workflow.pm
+++ b/core/server/OpenXPKI/Client/UI/Workflow.pm
@@ -244,7 +244,7 @@ sub init_search {
     my $workflows = $self->send_command( 'get_workflow_instance_types' );
     return $self unless(defined $workflows);
 
-    $self->logger()->debug('Workflows ' . Dumper $workflows);
+    $self->logger()->trace('Workflows ' . Dumper $workflows);
 
     my $preset = {};
     if ($args->{preset}) {
@@ -252,10 +252,10 @@ sub init_search {
 
     } elsif (my $queryid = $self->param('query')) {
         my $result = $self->_client->session()->param('query_wfl_'.$queryid);
-        $preset = $result->{input}; 
+        $preset = $result->{input};
     }
 
-    $self->logger()->debug('Preset ' . Dumper $preset);
+    $self->logger()->trace('Preset ' . Dumper $preset);
 
     # TODO Sorting / I18
     my @wf_names = keys %{$workflows};
@@ -400,7 +400,7 @@ sub init_result {
         }
     }
 
-    $self->logger()->debug( "persisted query: " . Dumper $result);
+    $self->logger()->trace( "persisted query: " . Dumper $result);
 
     my $search_result = $self->send_command( 'search_workflow_instances', $query );
 
@@ -511,17 +511,17 @@ sub init_pager {
     my $query = $result->{query};
     $query->{LIMIT} = $limit;
     $query->{START} = $startat;
-    
+
     if ($self->param('order')) {
         $query->{ORDER} = uc($self->param('order'));
-    } 
-    
+    }
+
     if (defined $self->param('reverse')) {
         $query->{REVERSE} = $self->param('reverse');
     }
 
-    $self->logger()->debug( "persisted query: " . Dumper $result);
-    $self->logger()->debug( "executed query: " . Dumper $query);    
+    $self->logger()->trace( "persisted query: " . Dumper $result);
+    $self->logger()->trace( "executed query: " . Dumper $query);
 
     my $search_result = $self->send_command( 'search_workflow_instances', $query );
 
@@ -563,7 +563,7 @@ sub init_history {
 
     my $workflow_history = $self->send_command( 'get_workflow_history', { ID => $id } );
 
-    $self->logger()->debug( "dumper result: " . Dumper $workflow_history);
+    $self->logger()->trace( "dumper result: " . Dumper $workflow_history);
 
     my $i = 1;
     my @result;
@@ -706,7 +706,7 @@ sub init_task {
         return $self->redirect('home');
     }
 
-    $self->logger()->debug( "got tasklist: " . Dumper $tasklist);
+    $self->logger()->trace( "got tasklist: " . Dumper $tasklist);
 
     TASKLIST:
     foreach my $item (@$tasklist) {
@@ -740,8 +740,8 @@ sub init_task {
 
         # create the header from the columns spec
         my ($header, $column) = $self->__render_list_spec( \@cols );
-        
-        $self->logger()->debug( "columns : " . Dumper $column);
+
+        $self->logger()->trace( "columns : " . Dumper $column);
 
         my $search_result = $self->send_command( 'search_workflow_instances', { (LIMIT => $limit), %$query } );
 
@@ -912,7 +912,7 @@ sub action_index {
 
     my $wf_args = $self->__fetch_wf_token( $wf_token );
 
-    $self->logger()->debug( "wf args: " . Dumper $wf_args);
+    $self->logger()->trace( "wf args: " . Dumper $wf_args);
 
     # check for delegation
     if ($wf_args->{wf_handler}) {
@@ -925,7 +925,7 @@ sub action_index {
         my @fields = map { $_->{name} } @{$wf_args->{wf_fields}};
         my $fields = $self->param( \@fields );
         %wf_param = %{ $fields } if ($fields);
-        $self->logger()->debug( "wf fields: " . Dumper $fields );
+        $self->logger()->trace( "wf fields: " . Dumper $fields );
     }
 
     # take over params from token, if any
@@ -938,7 +938,7 @@ sub action_index {
         $wf_param{$key} = $self->serializer()->serialize($wf_param{$key}) if (ref $wf_param{$key});
     }
 
-    $self->logger()->debug( "wf params: " . Dumper \%wf_param );
+    $self->logger()->trace( "wf params: " . Dumper \%wf_param );
 
     if ($wf_args->{wf_id}) {
 
@@ -1132,7 +1132,7 @@ sub action_select {
     my $wf_info = $self->send_command( 'get_workflow_info', {
         ID => $wf_id, UIINFO => 1
     });
-    $self->logger()->debug('wf_info ' . Dumper  $wf_info);
+    $self->logger()->trace('wf_info ' . Dumper  $wf_info);
 
     if (!$wf_info) {
         $self->set_status('I18N_OPENXPKI_UI_WORKFLOW_UNABLE_TO_LOAD_WORKFLOW_INFORMATION','error');
@@ -1220,7 +1220,7 @@ sub action_search {
 
     $query->{ATTRIBUTE} = \@attr;
 
-    $self->logger()->debug("query : " . Dumper $query);
+    $self->logger()->trace("query : " . Dumper $query);
 
     my $result_count = $self->send_command( 'search_workflow_instances_count', $query );
 
@@ -1288,7 +1288,7 @@ sub action_bulk {
             $errors->{$id} = $self->_status()->{message};
         } else {
             push @success, $wf_info;
-            $self->logger()->debug('Result on '.$id.': '. Dumper $wf_info);
+            $self->logger()->trace('Result on '.$id.': '. Dumper $wf_info);
         }
 
     }
@@ -1315,8 +1315,8 @@ sub action_bulk {
             $_->[ $pos_state ] = $errors->{$serial};
         } @result_failed;
 
-        $self->logger()->debug('Mangled failed result: '. Dumper \@result_failed);
-            
+        $self->logger()->trace('Mangled failed result: '. Dumper \@result_failed);
+
         my @fault_head = @{$self->__default_grid_head};
         $fault_head[$pos_state] = { sTitle => 'Error' };
 
@@ -1436,7 +1436,7 @@ sub __render_from_workflow {
     my $self = shift;
     my $args = shift;
 
-    $self->logger()->debug( "render args: " . Dumper $args);
+    $self->logger()->trace( "render args: " . Dumper $args);
 
     my $wf_info = $args->{WF_INFO} || undef;
     my $view = $args->{VIEW} || '';
@@ -1448,7 +1448,7 @@ sub __render_from_workflow {
         $args->{WF_INFO} = $wf_info;
     }
 
-    $self->logger()->debug( "wf_info: " . Dumper $wf_info);
+    $self->logger()->trace( "wf_info: " . Dumper $wf_info);
     if (!$wf_info) {
         $self->set_status('I18N_OPENXPKI_UI_WORKFLOW_UNABLE_TO_LOAD_WORKFLOW_INFORMATION','error');
         return $self;
@@ -1696,7 +1696,7 @@ sub __render_from_workflow {
             return $self->__delegate_call($wf_action_info->{uihandle}, $args, $wf_action);
         }
 
-        $self->logger()->debug('activity info ' . Dumper $wf_action_info );
+        $self->logger()->trace('activity info ' . Dumper $wf_action_info );
 
         # we allow prefill of the form if the workflow is started
         my $do_prefill = $wf_info->{WORKFLOW}->{STATE} eq 'INITIAL';
@@ -1794,12 +1794,12 @@ sub __render_from_workflow {
         });
 
         my $fields = $self->__render_fields( $wf_info, $view );
-        
-        $self->logger()->debug('Field data ' . Dumper $fields);
-                
-        # Add action buttons 
-        my $buttons = $self->__get_action_buttons( $wf_info ) ;        
-        
+
+        $self->logger()->trace('Field data ' . Dumper $fields);
+
+        # Add action buttons
+        my $buttons = $self->__get_action_buttons( $wf_info ) ;
+
         # Workflows can render grids -> only one field with format = grid
         if (scalar @{$fields} == 1 && $fields->[0]->{format} eq 'grid') {
 
@@ -2004,7 +2004,7 @@ sub __get_action_buttons {
        push @buttons, \%button;
     }
 
-    $self->logger()->debug('Buttons are ' . Dumper \@buttons);
+    $self->logger()->trace('Buttons are ' . Dumper \@buttons);
 
     return \@buttons;
 }
@@ -2159,7 +2159,7 @@ sub __render_result_list {
     my $search_result = shift;
     my $colums = shift;
 
-    $self->logger()->debug("search result " . Dumper $search_result);
+    $self->logger()->trace("search result " . Dumper $search_result);
 
     my @result;
 
@@ -2189,7 +2189,7 @@ sub __render_result_list {
             # we need to load the wf info
             if (!$wf_info && ($col->{template} || $col->{source} ne 'workflow')) {
                 $wf_info = $self->send_command( 'get_workflow_info', { ID => $wf_item->{'WORKFLOW.WORKFLOW_SERIAL'}, ATTRIBUTE => 1 });
-                $self->logger()->debug( "fetch wf info : " . Dumper $wf_info);
+                $self->logger()->trace( "fetch wf info : " . Dumper $wf_info);
                 $context = $wf_info->{WORKFLOW}->{CONTEXT};
                 $attrib = $wf_info->{WORKFLOW}->{ATTRIBUTE};
             }
@@ -2326,7 +2326,7 @@ sub __render_fields {
             }
         } elsif ($output) {
             @fields_to_render = @{$wf_info->{STATE}->{output}};
-            $self->logger()->debug('Render output rules: ' . Dumper  \@fields_to_render  );
+            $self->logger()->trace('Render output rules: ' . Dumper  \@fields_to_render  );
 
         } else {
             foreach my $field (sort keys %{$context}) {
@@ -2334,7 +2334,7 @@ sub __render_fields {
                 next if ($field =~ m{ \A (wf_|_|workflow_id|sources) }x);
                 push @fields_to_render, { name => $field };
             }
-            $self->logger()->debug('No output rules, render plain context: ' . Dumper  \@fields_to_render  );
+            $self->logger()->trace('No output rules, render plain context: ' . Dumper  \@fields_to_render  );
         }
 
         foreach my $field (@fields_to_render) {
@@ -2410,7 +2410,7 @@ sub __render_fields {
                     };
                 }
 
-                $self->logger()->debug( 'item ' . Dumper $item);
+                $self->logger()->trace( 'item ' . Dumper $item);
 
             # add a redirect command to the page
             } elsif ($item->{format} eq "redirect") {
@@ -2485,7 +2485,7 @@ sub __render_fields {
 
                     my $fields = $self->send_command( 'get_field_definition',
                         { PROFILE => $cert_profile, STYLE => $cert_subject_style, 'SECTION' =>  'info' });
-                    $self->logger()->debug( 'Profile fields' . Dumper $fields );
+                    $self->logger()->trace( 'Profile fields' . Dumper $fields );
 
                     foreach my $field (@$fields) {
                         # this still uses "old" syntax - adjust after API refactoring
@@ -2555,7 +2555,7 @@ sub __render_fields {
 
                 my $param = { value => $item->{value} };
 
-                $self->logger()->debug('Render output using template on field '.$key.', '. $field->{template} . ', params:  ' . Dumper $param);
+                $self->logger()->trace('Render output using template on field '.$key.', '. $field->{template} . ', params:  ' . Dumper $param);
 
                 # Rendering target depends on value format
                 # deflist iterates over each key/label pair and sets the return value into the label
@@ -2573,7 +2573,7 @@ sub __render_fields {
                     $self->logger()->debug('Return from template ' . $out );
                     if ($out) {
                         my @val = split /\s*\|\s*/, $out;
-                        $self->logger()->debug('Split ' . Dumper \@val);
+                        $self->logger()->trace('Split ' . Dumper \@val);
                         $item->{value} = \@val;
                     } else {
                         $item->{value} = undef; # prevent pusing emtpy lists

--- a/core/server/OpenXPKI/Connector/DataPool.pm
+++ b/core/server/OpenXPKI/Connector/DataPool.pm
@@ -45,7 +45,7 @@ sub get {
         $ttarg->{EXTRA} = $params->{extra};
     }
 
-    $self->log()->debug('Template args ' . Dumper $ttarg );
+    $self->log()->trace('Template args ' . Dumper $ttarg );
 
     # Process the key using template if necessary
     my $key = $self->key();
@@ -144,7 +144,7 @@ sub set {
 
     my @args = $self->_build_path( $args );
 
-    $self->log()->debug('Set called on ' . Dumper \@args );
+    $self->log()->trace('Set called on ' . Dumper \@args );
 
     my $template = Template->new({});
 
@@ -156,7 +156,7 @@ sub set {
         $ttarg->{EXTRA} = $params->{extra};
     }
 
-    $self->log()->debug('Template args ' . Dumper $ttarg );
+    $self->log()->trace('Template args ' . Dumper $ttarg );
     # Process the key using template
     my $key = $self->key();
     my $parsed_key;

--- a/core/server/OpenXPKI/SOAP/Revoke.pm
+++ b/core/server/OpenXPKI/SOAP/Revoke.pm
@@ -18,7 +18,7 @@ my $log = $main::config->logger();
 
 $log->info("SOAP interface NG initialized ");
 
-#$log->debug('Env ' . Dumper \%ENV);
+#$log->trace('Env ' . Dumper \%ENV);
 
 sub __dispatch_revoke {
 
@@ -127,14 +127,14 @@ sub __dispatch_revoke {
             invalidity_time => 0,
         );
 
-        $log->debug( "WF parameters: " . Dumper \%param );
+        $log->trace( "WF parameters: " . Dumper \%param );
 
         $workflow = $client->handle_workflow({
             TYPE => $workflow_type,
             PARAMS => \%param
         });
 
-        $log->debug( 'Workflow info '  . Dumper $workflow );
+        $log->trace( 'Workflow info '  . Dumper $workflow );
     };
 
     my $res;

--- a/core/server/OpenXPKI/SOAP/Smartcard.pm
+++ b/core/server/OpenXPKI/SOAP/Smartcard.pm
@@ -18,7 +18,7 @@ my $log = $main::config->logger();
 
 $log->info("SOAP interface NG initialized ");
 
-#$log->debug('Env ' . Dumper \%ENV);
+#$log->trace('Env ' . Dumper \%ENV);
 
 # Adjust path to binary!
 sub RevokeSmartcard {
@@ -98,14 +98,14 @@ sub RevokeSmartcard {
             signer_cert => $auth_pem
         );
 
-        $log->debug( "WF parameters: " . Dumper \%param );
+        $log->trace( "WF parameters: " . Dumper \%param );
 
         $workflow = $client->handle_workflow({
             TYPE => $workflow_type,
             PARAMS => \%param
         });
 
-        $log->debug( 'Workflow info '  . Dumper $workflow );
+        $log->trace( 'Workflow info '  . Dumper $workflow );
     };
 
     if ( my $exc = OpenXPKI::Exception->caught() ) {

--- a/core/server/OpenXPKI/Server/Workflow/Activity/SmartCard/CheckPrereqs.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity/SmartCard/CheckPrereqs.pm
@@ -60,8 +60,7 @@ sub execute {
 
     $context->param('_workflows', $result->{WORKFLOWS});
     if ($wf_types) {
-        CTX('log')->application()->debug('SmartCard found existing workflows: ' . Dumper $result->{WORKFLOWS});
-
+        CTX('log')->application()->trace('SmartCard found existing workflows: ' . Dumper $result->{WORKFLOWS});
     }
 
 	# set cert ids in context

--- a/core/server/OpenXPKI/Server/Workflow/Activity/Tools/RenderSubject.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity/Tools/RenderSubject.pm
@@ -60,9 +60,7 @@ sub execute {
 
 
     ##! 16: 'Cleaned subject_vars' . Dumper $subject_vars
-
-    CTX('log')->application()->debug("Subject render input vars " . Dumper $subject_vars);
-
+    CTX('log')->application()->trace("Subject render input vars " . Dumper $subject_vars);
 
     my $cert_subject = CTX('api')->render_subject_from_template({
         PROFILE => $profile,

--- a/core/server/OpenXPKI/Server/Workflow/Activity/Tools/RevokeCertificate.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity/Tools/RevokeCertificate.pm
@@ -82,7 +82,7 @@ sub execute {
     }
 
     ##! 32: 'Prepare revocation with params: ' . Dumper $param
-    CTX('log')->application()->debug('Prepare revocation with params: ' . Dumper $param);
+    CTX('log')->application()->trace('Prepare revocation with params: ' . Dumper $param);
 
 
     # Parse invalidity_time if set - workflow requires epoch

--- a/core/server/OpenXPKI/Server/Workflow/Activity/Tools/SearchCertificates.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity/Tools/SearchCertificates.pm
@@ -169,8 +169,7 @@ sub execute
         my $ser = OpenXPKI::Serialization::Simple->new();
         $context->param( $target_key , $ser->serialize(\@identifier) );
 
-        CTX('log')->application()->debug("SearchCertificates result " . Dumper \@identifier);
-
+        CTX('log')->application()->trace("SearchCertificates result " . Dumper \@identifier);
 
     } else {
 

--- a/core/server/OpenXPKI/Server/Workflow/Condition/Approved.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Condition/Approved.pm
@@ -86,7 +86,7 @@ sub evaluate
         }
     }
 
-    CTX('log')->application()->debug("Too few approvals, missing: " . Dumper \%required);
+    CTX('log')->application()->trace("Too few approvals, missing: " . Dumper \%required);
 
 
     ## if the required list contains still some requirements

--- a/core/server/OpenXPKI/Server/Workflow/Validator/CertIdentifierExists.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Validator/CertIdentifierExists.pm
@@ -41,8 +41,7 @@ sub _validate {
         validation_error("I18N_OPENXPKI_UI_VALIDATOR_CERT_IDENTIFIER_EXISTS_NOT_AN_ENTITY");
     }
 
-    CTX('log')->application()->debug("Found certificate, hash is " . Dumper $cert);
-
+    CTX('log')->application()->trace("Found certificate, hash is " . Dumper $cert);
 
     return 1;
 }

--- a/core/server/OpenXPKI/Workflow/Config.pm
+++ b/core/server/OpenXPKI/Workflow/Config.pm
@@ -360,7 +360,7 @@ sub __process_action {
     my $param = $conn->get_hash([ @path, 'param' ] );
     map {  $action->{$_} = $param->{$_} } keys %{$param};
 
-    CTX('log')->workflow()->debug("Adding action " . (Dumper $action));
+    CTX('log')->workflow()->trace("Adding action " . (Dumper $action));
 
 
     push @{$self->_workflow_config()->{action}}, $action;
@@ -417,7 +417,7 @@ sub __process_condition {
         $condition->{param} = \@param;
     }
 
-    CTX('log')->workflow()->debug("Adding condition " . (Dumper $condition));
+    CTX('log')->workflow()->trace("Adding condition " . (Dumper $condition));
 
 
     push @{$self->_workflow_config()->{condition}}, $condition;
@@ -475,7 +475,7 @@ sub __process_validator {
         $validator->{param} = \@param;
     }
 
-    CTX('log')->workflow()->debug("Adding validator " . (Dumper $validator));
+    CTX('log')->workflow()->trace("Adding validator " . (Dumper $validator));
 
 
     push @{$self->_workflow_config()->{validator}}, $validator;

--- a/core/server/cgi-bin/rpc.fcgi
+++ b/core/server/cgi-bin/rpc.fcgi
@@ -116,9 +116,9 @@ while (my $cgi = CGI::Fast->new()) {
     } else {
         $log->debug("RPC unauthenticated (plain http)");
     }
-     
-    $log->debug( "WF parameters: " . Dumper $param );
-        
+
+    $log->trace( "WF parameters: " . Dumper $param );
+
     my $workflow;
     my $client;
     eval {
@@ -145,8 +145,8 @@ while (my $cgi = CGI::Fast->new()) {
             TYPE => $workflow_type,
             PARAMS => $param
         });
-        
-        $log->debug( 'Workflow info '  . Dumper $workflow );
+
+        $log->trace( 'Workflow info '  . Dumper $workflow );
     };
 
     my $res;
@@ -183,7 +183,7 @@ while (my $cgi = CGI::Fast->new()) {
             my @keys;
             @keys = split /\s*,\s*/, $conf->{$method}->{output};
             $log->debug("Keys " . join(", ", @keys));
-            $log->debug("Raw context: ". Dumper $workflow->{CONTEXT});
+            $log->trace("Raw context: ". Dumper $workflow->{CONTEXT});
             foreach my $key (@keys) {
                 my $val = $workflow->{CONTEXT}->{$key};
                 next unless (defined $val);

--- a/core/server/cgi-bin/sc.fcgi
+++ b/core/server/cgi-bin/sc.fcgi
@@ -62,8 +62,8 @@ while (my $cgi = CGI::Fast->new()) {
     my %global = %{$conf->{global}};
     my %auth   = %{$conf->{auth}};
 
-    $log->debug('Global ' . Dumper \%global );
-    $log->debug('Auth ' . Dumper \%auth );
+    $log->trace('Global ' . Dumper \%global );
+    $log->trace('Auth ' . Dumper \%auth );
 
     my $client = OpenXPKI::Client::SC->new({
         session => $session_front,

--- a/core/server/cgi-bin/webui.fcgi
+++ b/core/server/cgi-bin/webui.fcgi
@@ -277,7 +277,7 @@ while (my $cgi = CGI::Fast->new()) {
     push @header, ('-cookie', $cgi->cookie( $cookie ));
     push @header, ('-type','application/json; charset=UTF-8');
 
-    $log->debug('Init UI using backend ' . Dumper $backend_client);
+    $log->trace('Init UI using backend ' . Dumper $backend_client);
 
     my $result;
     eval {


### PR DESCRIPTION
This makes the log files less cluttered with detail informations. It allows to use DEBUG to trace the application flow in detail while still sustaining a certain level of clarity.