### PR TITLE
Fix search_cert (Oracle) for ORDER = 'identifier' (fixes #575)

### DIFF
--- a/core/server/OpenXPKI/Server/API/Object.pm
+++ b/core/server/OpenXPKI/Server/API/Object.pm
@@ -1083,7 +1083,7 @@ sub __search_cert_db_query {
     $desc = "" if defined $args->{REVERSE} and $args->{REVERSE} == 0;
     # TODO #legacydb Code that removes table name prefix
     $args->{ORDER} =~ s/^CERTIFICATE\.// if $args->{ORDER};
-    $params->{order_by} = sprintf "%s%s", $desc, ($args->{ORDER} // 'cert_key');
+    $params->{order_by} = sprintf "%scertificate.%s", $desc, lc($args->{ORDER} // 'cert_key');
 
     # Handle status
     if ($args->{STATUS} and $args->{STATUS} eq 'EXPIRED') {

--- a/qatest/backend/api/15_search_cert.t
+++ b/qatest/backend/api/15_search_cert.t
@@ -36,7 +36,7 @@ my $test = OpenXPKI::Test::More->new({
 }) or die "Error creating new test instance: $@";
 
 $test->set_verbose($cfg->{instance}{verbose});
-$test->plan( tests => 56 );
+$test->plan( tests => 58 );
 
 $test->connect_ok(
     user => $cfg->{operator}{name},
@@ -318,6 +318,20 @@ $test->runcmd_ok('search_cert', {
     PROFILE => $cert_info->{profile},
     PKI_REALM => "_ANY"
 }, "Search cert by attributes and profile (issue #501)") or diag ref($test->error);
+
+cmp_deeply $test->get_msg->{PARAMS}, [
+    superhashof({ SUBJECT => re(qr/$uuid/i) })
+], "Correct result";
+
+# Github issue #575 - search_cert fails on Oracle when order = identifier
+$test->runcmd_ok('search_cert', {
+    CERT_ATTRIBUTES => [
+        { KEY => 'meta_requestor', VALUE => "*$uuid*" }, # default operator is LIKE
+        { KEY => 'meta_email', VALUE => 'tilltom@morning', OPERATOR => 'EQUAL' },
+    ],
+    ORDER => "IDENTIFIER",
+    PKI_REALM => "_ANY"
+}, "Search cert by attributes and with ORDER = 'identifier' (issue #575)") or diag ref($test->error);
 
 cmp_deeply $test->get_msg->{PARAMS}, [
     superhashof({ SUBJECT => re(qr/$uuid/i) })


### PR DESCRIPTION
Also always convert attribute ORDER to lowercase (only affects case sensitive RDBMS).

search_cert failed because of the SQL JOIN seeing an ambiguous column name when searching for certificate attributes and specifying ORDER = 'identifier'.