### PR TITLE
utf8 transport (support more encodings)

### DIFF
--- a/core/server/OpenXPKI/Server/Notification/SMTP.pm
+++ b/core/server/OpenXPKI/Server/Notification/SMTP.pm
@@ -103,6 +103,7 @@ use OpenXPKI::Serialization::Simple;
 use Net::SMTP;
 
 use Moose;
+use Encode;
 
 extends 'OpenXPKI::Server::Notification::Base';
 
@@ -561,10 +562,11 @@ sub _send_html {
     }
 
     my @args = (
-        From    => $cfg->{from},
-        To      => $vars->{to},
-        Subject => "$vars->{prefix} $subject",
+        From    => Encode::encode_utf8($cfg->{from}),
+        To      => Encode::encode_utf8($vars->{to}),
+        Subject => Encode::encode_utf8("$vars->{prefix} $subject"),
         Type    =>'multipart/alternative',
+        Charset => 'UTF-8',
     );
 
     push @args, (Cc => join(",", @{$vars->{cc}})) if ($vars->{cc});
@@ -579,7 +581,7 @@ sub _send_html {
         ##! 16: ' Attach plain text'
         $msg->attach(
             Type     =>'text/plain',
-            Data     => $plain
+            Data     => Encode::encode_utf8($plain)
         );
     }
 
@@ -597,7 +599,7 @@ sub _send_html {
         # The HTML Body
         $html_part->attach(
             Type        =>'text/html',
-            Data        => $html
+            Data        => Encode::encode_utf8($html)
         );
 
         # The hash contains the image id and the filename
@@ -633,7 +635,7 @@ sub _send_html {
         ## Add the html part:
         $msg->attach(
             Type        =>'text/html',
-            Data        => $html
+            Data        => Encode::encode_utf8($html)
         );
     }
 

--- a/core/server/OpenXPKI/Transport/Simple.pm
+++ b/core/server/OpenXPKI/Transport/Simple.pm
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use Encode;
 
 package OpenXPKI::Transport::Simple;
 
@@ -51,11 +52,8 @@ sub write
 
     my @list = ();
 
-    # The data string might have the utf8 flag set - to prevent messing with
-    # wide chars / length issues on the transport, we do a "downgrade" which
-    # will make the string look like a sequence of 8-bit chars.
-    # We will upgrade on the other side of the transport again
-    utf8::downgrade( $data );
+    # Encode data from perl internal utf8 representation to octets
+    $data = Encode::encode_utf8( $data );
 
 #    $data = encode_base64( $data );
 
@@ -164,9 +162,8 @@ sub read
 
 
 #    $msg = decode_base64( $msg );
-    # Transmission is done with plain 8-bit, we make the string "be" utf8
-    # again by calling upgrade. See docs for known issues
-    utf8::upgrade( $msg );
+    # Decode octets in $msg to the perl utf8 string.
+    $msg = Encode::decode_utf8($msg, Encode::LEAVE_SRC | Encode::FB_CROAK);
 
     return $msg;
 }


### PR DESCRIPTION
Use `Encode::encode_utf8` instead of `utf8::downgrade` and `Encode::decode_utf8` instead of `utf8::upgrade`. The `utf8::` functions support only latin1/EBCDIC subsed of characters and, for example, don't work with latin2 characters.

This patch also adds UTF-8 support to SMTP notifications. Not sure whether it alters or not the other notification methods.