### PR TITLE
Support for OCSPSigning extended key usage

### DIFF
--- a/config/openxpki/config.d/realm/ca-one/profile/I18N_OPENXPKI_PROFILE_TLS_CLIENT.yaml
+++ b/config/openxpki/config.d/realm/ca-one/profile/I18N_OPENXPKI_PROFILE_TLS_CLIENT.yaml
@@ -54,4 +54,5 @@ extensions:
         email_protection: 0
         code_signing:     0
         time_stamping:    0
+        ocsp_signing:     0
 

--- a/config/openxpki/config.d/realm/ca-one/profile/I18N_OPENXPKI_PROFILE_TLS_SERVER.yaml
+++ b/config/openxpki/config.d/realm/ca-one/profile/I18N_OPENXPKI_PROFILE_TLS_SERVER.yaml
@@ -92,6 +92,7 @@ extensions:
         email_protection: 0
         code_signing:     0
         time_stamping:    0
+        ocsp_signing:     0
 
 
     # This is really outdated and should not be used unless really necessary

--- a/config/openxpki/config.d/realm/ca-one/profile/I18N_OPENXPKI_PROFILE_USER.yaml
+++ b/config/openxpki/config.d/realm/ca-one/profile/I18N_OPENXPKI_PROFILE_USER.yaml
@@ -50,6 +50,7 @@ extensions:
         email_protection: 1
         code_signing:     0
         time_stamping:    0
+        ocsp_signing:     0
         # MS Smartcard Logon
         1.3.6.1.4.1.311.20.2.2: 1
 

--- a/config/openxpki/config.d/realm/ca-one/profile/sample.yaml
+++ b/config/openxpki/config.d/realm/ca-one/profile/sample.yaml
@@ -111,6 +111,7 @@ extensions:
         email_protection: 0
         code_signing:     0 
         time_stamping:    0
+        ocsp_signing:     0
         # Any other oid can be given by number
         1.3.6.1.4.1.311.20.2.2: 0
          

--- a/config/profiles/I18N_OPENXPKI_PROFILE_OPENVPN_CLIENT.yaml
+++ b/config/profiles/I18N_OPENXPKI_PROFILE_OPENVPN_CLIENT.yaml
@@ -57,8 +57,9 @@ extensions:
         client_auth:      1
         server_auth:      0
         email_protection: 0
-        codeSigning:      0
-        timeStamping:     0
+        code_signing:     0
+        time_stamping:    0
+        ocsp_signing:     0
  
 
 

--- a/config/profiles/I18N_OPENXPKI_PROFILE_SCEP_CLIENT.yaml
+++ b/config/profiles/I18N_OPENXPKI_PROFILE_SCEP_CLIENT.yaml
@@ -51,6 +51,7 @@ extensions:
         client_auth:      1
         server_auth:      0
         email_protection: 0
-        codeSigning:      0
-        timeStamping:     0
+        code_signing:     0
+        time_stamping:    0
+        ocsp_signing:     0
 

--- a/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Config.pm
+++ b/core/server/OpenXPKI/Crypto/Backend/OpenSSL/Config.pm
@@ -590,6 +590,7 @@ sub __get_extensions
             $config .= "emailProtection," if (grep /email_protection/, @bits);
             $config .= "codeSigning,"     if (grep /code_signing/, @bits);
             $config .= "timeStamping,"    if (grep /time_stamping/, @bits);
+            $config .= "OCSPSigning,"     if (grep /ocsp_signing/, @bits);
             my @oids = grep m{\.}, @bits;
             foreach my $oid (@oids)
             {

--- a/core/server/OpenXPKI/Crypto/Profile/Base.pm
+++ b/core/server/OpenXPKI/Crypto/Profile/Base.pm
@@ -128,7 +128,7 @@ sub load_extension
     {
         my $bits_set = $config->get_hash("$path");
         ##! 16: "ext key usage bits: ". Dumper $bits_set
-        my @bits = ( "client_auth", "server_auth","email_protection","code_signing","time_stamping");
+        my @bits = ( "client_auth", "server_auth","email_protection","code_signing","time_stamping", "ocsp_signing");
 
         foreach my $bit (@bits) {
             push @values, $bit if ( $bits_set->{$bit} );

--- a/core/server/t/lib/OpenXPKI/Test/ConfigWriter.pm
+++ b/core/server/t/lib/OpenXPKI/Test/ConfigWriter.pm
@@ -659,6 +659,7 @@ sub _build_cert_profile_client {
                 email_protection => 0,
                 server_auth      => 0,
                 time_stamping    => 0,
+                ocsp_signing     => 0,
             },
             key_usage => {
                 critical          => 1,


### PR DESCRIPTION
Add ocsp_signing as new extended key usage flag in config parser.
Fixed incorrectly referenced tags for time_stamping and code_signing.