### PR TITLE
Move config path check from O:Workflow::Config to O:Workflow::Handler

### DIFF
--- a/core/server/OpenXPKI/Workflow/Config.pm
+++ b/core/server/OpenXPKI/Workflow/Config.pm
@@ -35,10 +35,22 @@ sub _build_workflow_config {
 
     my $conn = $self->_config();
 
-    # Init the structure
+    # Fetch serialized workflow definition from config layer
+    if (!$conn->exists('workflow.def')) {
+        my $pki_realm = CTX('session')->data->pki_realm;
+        OpenXPKI::Exception->throw(
+            message => 'No workflow configuration found for current realm',
+            params => {
+                realm => $pki_realm,
+                config_path => "realm.$pki_realm.workflow.def",
+            },
+        );
+    }
+
+    # Init structure
     $self->_workflow_config({ condition => [], validator => [], action =>[], workflow => [], persister => [] });
 
-    # Add Persisters
+    # Add persisters
     my @persister = $conn->get_keys('workflow.persister');
     foreach my $persister (@persister) {
         my $conf = $conn->get_hash(['workflow','persister', $persister]);

--- a/core/server/OpenXPKI/Workflow/Handler.pm
+++ b/core/server/OpenXPKI/Workflow/Handler.pm
@@ -142,18 +142,10 @@ sub get_factory {
     ##! 16: Dumper $args
 
     my $pki_realm = CTX('session')->data->pki_realm;
+
     # Check if we already have that factory in the cache
     if (defined $self->_cache->{ $pki_realm } ) {
         return $self->_cache->{ $pki_realm };
-    }
-
-    # Fetch the serialized Workflow definition from the config layer
-    my $conn = CTX('config');
-
-    if (!$conn->exists('workflow.def')) {
-         OpenXPKI::Exception->throw(
-            message => 'I18N_OPENXPKI_WORKFLOW_FACTORY_NO_CONFIG_FOUND',
-        );
     }
 
     my $yaml_config = OpenXPKI::Workflow::Config->new()->workflow_config();


### PR DESCRIPTION
It does not make sense to have two places where the config paths are
spelled out.