### PR TITLE
Allow direct client side calls to the new API (API2)

### DIFF
--- a/core/server/OpenXPKI/Service/Default.pm
+++ b/core/server/OpenXPKI/Service/Default.pm
@@ -28,6 +28,7 @@ use OpenXPKI::Server;
 use OpenXPKI::Server::Session;
 use OpenXPKI::Server::Context qw( CTX );
 use OpenXPKI::Service::Default::Command;
+use OpenXPKI::Service::Default::CommandApi2;
 use Log::Log4perl::MDC;
 
 my %state_of :ATTR;     # the current state of the service
@@ -714,6 +715,12 @@ sub __handle_COMMAND : PRIVATE {
 
     my $command;
     eval {
+        if ($data->{PARAMS}->{API2}) {
+            $command = OpenXPKI::Service::Default::CommandApi2->new(
+                command => $data->{PARAMS}->{COMMAND},
+                params  => $data->{PARAMS}->{PARAMS},
+            );
+        }
         $command = OpenXPKI::Service::Default::Command->new({
             COMMAND => $data->{PARAMS}->{COMMAND},
             PARAMS  => $data->{PARAMS}->{PARAMS},

--- a/core/server/OpenXPKI/Service/Default/CommandApi2.pm
+++ b/core/server/OpenXPKI/Service/Default/CommandApi2.pm
@@ -1,0 +1,80 @@
+package OpenXPKI::Service::Default::CommandApi2;
+use Moose;
+
+=head1 NAME
+
+OpenXPKI::Service::Default::CommandApi2 - Execute commands via new API
+
+=cut
+
+# Project modules
+use OpenXPKI::Exception;
+use OpenXPKI::Server::API2;
+
+=head1 DESCRIPTION
+
+Default service command class to execute commands via the new API (API2).
+
+=cut
+
+has api => (
+    is => 'rw',
+    isa => 'OpenXPKI::Server::API2',
+    lazy => 1,
+    default => sub { OpenXPKI::Server::API2->new(enable_acls => 0) },
+);
+
+has command => (
+    is => 'ro',
+    isa => 'Str',
+    required => 1,
+);
+
+has params => (
+    is => 'ro',
+    isa => 'HashRef',
+    required => 1,
+);
+
+
+=head1 METHODS
+
+=head2 new
+
+Stores command and parameters for later execution via API.
+
+B<Parameters>
+
+=over
+
+=item * C<command> I<Str> - API command name
+
+=item * C<params> I<HashRef> - command parameters
+
+=head2 execute
+
+Executes the command via API.
+
+Returns a data structure that can be serialized and directly returned to the
+client:
+
+    {
+        SERVICE_MSG => 'COMMAND',
+        COMMAND => $command,
+        PARAMS  => $api_call_result,
+    }
+
+=cut
+sub execute {
+    my $self = shift;
+    return {
+        SERVICE_MSG => 'COMMAND',
+        COMMAND => $self->command,
+        PARAMS  => $self->api->dispatch(
+            command => $self->command,
+            params  => $self->params,
+        ),
+    };
+}
+
+__PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Adds a new parameter 'API2' to service message 'COMMAND'.
This is currently only used in tests.