### PR TITLE
rework fix for closing connections #645

### DIFF
--- a/core/server/OpenXPKI/Client.pm
+++ b/core/server/OpenXPKI/Client.pm
@@ -497,8 +497,8 @@ sub close_connection {
     close($socket{$ident});
 }
 
-sub DESTROY {
-    ##! 4: 'Destroy'
+sub DEMOLISH {
+    ##! 4: 'Demolish'
     my $self = shift;
     $self->close_connection();
 }


### PR DESCRIPTION
DESTROY() is reserved by Class::Std - define DEMOLISH() instead