### PR TITLE
Render templates for reply and cc fields for SMTP notifications

### DIFF
--- a/core/server/OpenXPKI/Server/Notification/SMTP.pm
+++ b/core/server/OpenXPKI/Server/Notification/SMTP.pm
@@ -592,8 +592,8 @@ sub _send_html {
         Charset => 'UTF-8',
     );
 
-    push @args, (Cc => join(",", @{$vars->{cc}})) if ($vars->{cc});
-    push @args, ("Reply-To" => $cfg->{reply}) if ($cfg->{reply});
+    push @args, (Cc => $self->_render_template(join(",", @{$vars->{cc}}),$vars)) if ($vars->{cc});
+    push @args, ("Reply-To" => $self->_render_template($cfg->{reply},$vars)) if ($cfg->{reply});
 
     ##! 16: 'Building with args: ' . Dumper @args
 


### PR DESCRIPTION
Just as the to field is rendered. BTW the reply is needed even with the sample config in notification.smtp.message.csr_created.raop