### PR TITLE
Add html template for email expiry notification

### DIFF
--- a/config/openxpki/notification/email/cert_expiry.html
+++ b/config/openxpki/notification/email/cert_expiry.html
@@ -1,0 +1,27 @@
+<html><body>
+
+<img src="cid:banner" />
+
+<p>
+[% USE Certificate %]
+Dear [% IF data.requestor %][% data.requestor %][% ELSE %]certificate owner[% END %],</p>
+
+<p>
+our certificate for <b>[% Certificate.body( cert_identifier, 'subject') %]</b> expires
+at <b>[% Certificate.notafter( cert_identifier, 'printable') %]</b>!
+</p>
+
+<p>
+For further details of this certificate, check the certificate status page
+at <a href="[% meta_baseurl %]#/openxpki/certificate!detail!identifier![% cert_identifier %]">the PKI service portal</a>.
+</p>
+
+<p>
+Services depending on this certificate might become unavailable after this date!
+If the service is still in use, please make sure to request a new certificate
+in time. If you already renewed the certificate or the service is no longer in
+use, you can silently ignore this mail.
+</p>
+
+[% INCLUDE _footer.html %]
+</body></html>


### PR DESCRIPTION
This template is missing in the default config, while every other templates are both present in txt and html