### PR TITLE
Fix syntax error in PostgreSQL schema

### DIFF
--- a/config/sql/schema-psql.sql
+++ b/config/sql/schema-psql.sql
@@ -171,7 +171,7 @@ CREATE TABLE report (
     created numeric(49,0),
     mime_type text NOT NULL,
     description text NOT NULL,
-    report_value bytea NOT NULL,
+    report_value bytea NOT NULL
 );
 
 --


### PR DESCRIPTION
Removed an extra comma at the end of the report table create statement.