### PR TITLE
Optimized Docker test container; POD fix; optimized Vagrant test box script

### DIFF
--- a/core/server/OpenXPKI/Server/API2/Plugin/Cert/private_key.pm
+++ b/core/server/OpenXPKI/Server/API2/Plugin/Cert/private_key.pm
@@ -57,7 +57,7 @@ Obviously only useful with PKCS12 or Java Keystore.
 
 String to set as alias for the key/certificate for JKS or PKCS12.
 
-=item csp
+=item * csp
 
 String, write name as a Microsoft CSP name (PKCS12 only)
 

--- a/tools/docker-test/Dockerfile
+++ b/tools/docker-test/Dockerfile
@@ -64,6 +64,4 @@ ENV OXI_TEST_DB_MYSQL_NAME=openxpki \
 
 COPY startup.pl /
 RUN chmod 0755 startup.pl
-ENTRYPOINT ["/startup.pl"]
-# Defaults for "user+repo" and "branch" to test:
-#CMD ["develop", "openxpki/openxpki"]
+CMD ["/startup.pl"]

--- a/tools/docker-test/README.md
+++ b/tools/docker-test/README.md
@@ -8,9 +8,9 @@ Image specifications:
 * Standard system Perl v5.18.2
 * MySQL Server 5.5
 
-## Usage
+Please note that there is a wrapper that builds and executes this Docker image automatically:
 
-The easiest way to use this image is by calling `tools/docker-test.pl`.
+    tools/docker-test.pl
 
 ## (Re-)Build image
 
@@ -31,35 +31,57 @@ The list of preinstalled Perl modules for the Docker image is managed in `cpanfi
 
 After that, rebuild the Docker image as shown above.
 
-## Run tests on "develop" branch
+## Running tests
 
-Without any arguments the Docker container will fetch the "develop" branch from
-the official OpenXPKI Github repository and run the test suite:
+Mandatory and optional parameters for the Docker container must be given as environment variables. (They are processed by `startup.pl`):
 
-    # https://github.com/openxpki/openxpki.git, branch "develop"
-    docker run -t -i --rm oxi-test
+    OXI_TEST_ALL       - Bool: 1 = run all tests (this is the default)
+    OXI_TEST_COVERAGE  - Bool: 1 = run coverage tests
+    OXI_TEST_ONLY      - Str: comma separated list of relative paths to test dirs/files
+    OXI_TEST_GITREPO   - Str: Git repository
+    OXI_TEST_GITBRANCH - Str: Git branch, default branch if not specified
+
+If errors occur while executing tests a Bash shell will be opened. This allows you to figure out what went wrong.
+
+### Local repository
+
+To run tests on the local HEAD commit (not your working directory!) you have to mount your project root into the Docker directory `/repo` via `-v`:
+
+    docker run -ti --rm \
+      -v ~/prj/openxpki:/repo \
+      oxi-test
+
+You might choose another commit:
+
+    docker run -ti --rm \
+      -v ~/prj/openxpki:/repo \
+      -e OXI_TEST_GITBRANCH=feature \
+      oxi-test
+
+To only execute a particular test:
+
+    docker run -ti --rm \
+      -v ~/prj/openxpki:/repo \
+      -e OXI_TEST_ONLY=qatest/backend/api2/50_profiles.t \
+      oxi-test
+
+To only execute tests in two directories:
+
+    docker run -ti --rm \
+      -v ~/prj/openxpki:/repo \
+      -e OXI_TEST_ONLY=core/server/t/91_api2,qatest/backend/api2 \
+      oxi-test
+
+
+### Git repository, default branch
+
+    docker run -ti --rm \
+      -e OXI_TEST_GITREPO=https://github.com/openxpki/openxpki.git \
+      oxi-test
 
 ### Other Git branch
 
-To choose another branch than "develop", give it as first argument:
-
-    # https://github.com/openxpki/openxpki.git, branch "newfeature"
-    docker run -t -i --rm oxi-test newfeature
-
-### Other Github repository
-
-To choose another repository, give it as second argument:
-
-    # https://github.com/maxhq/openxpki.git, branch "fixes"
-    docker run -t -i --rm oxi-test fixes maxhq/openxpki
-
-### Use local repository
-
-To run the tests on a local HEAD commit (not your working directory!) you have
-to mount your host repository root into the Docker directory `/repo` via `-v`:
-
-    # /home/tux/oxi-dev, branch "develop"
-    docker run -t -i --rm -v /home/tux/oxi-dev:/repo oxi-test
-
-    # /home/tux/oxi-dev, branch "fixes"
-    docker run -t -i --rm -v /home/tux/oxi-dev:/repo oxi-test fixes
+    docker run -ti --rm \
+      -e OXI_TEST_GITREPO=https://github.com/openxpki/openxpki.git \
+      -e OXI_TEST_GITBRANCH=master \
+      oxi-test

--- a/tools/docker-test/startup.pl
+++ b/tools/docker-test/startup.pl
@@ -197,13 +197,14 @@ chdir "$clone_dir/core/server";
 #
 if ($mode eq "coverage") {
     print "\n====[ Testing the code coverage (this will take a while) ]====\n";
-    my $code = execute code => "cover -test";
-    print "Please note that some unit tests did not pass\n" if $code != 0;
+    execute show => "cover -test";
     use DateTime;
-    my $dirname = "code-coverage-".DateTime->new->strftime('%Y%m%d-%H%M%S');
+    my $dirname = "code-coverage-".(DateTime->now->strftime('%Y%m%d-%H%M%S'));
     move "./cover_db", "/repo/$dirname";
-    `chmod -R g+w,o+w "/repo/$dirname`;
-    print "\nCode coverage results available in project root dir:\n$dirname\n";
+    if (-d "/repo/$dirname") {
+        `chmod -R g+w,o+w "/repo/$dirname`;
+        print "\nCode coverage results available in project root dir:\n$dirname\n";
+    }
     exit;
 }
 

--- a/tools/docker-test/startup.pl
+++ b/tools/docker-test/startup.pl
@@ -91,6 +91,8 @@ if ($mode eq "all") {
 }
 elsif ($mode eq "selected") {
     my @tests = split /,/, $ENV{OXI_TEST_ONLY};
+    _stop 105, "Please specify one of the following variables:\ndocker run -e OXI_TEST_ALL=1 ...\ndocker run -e OXI_TEST_ONLY=relpath/to/test1.t,relpath/dir ...\ndocker run -e OXI_TEST_COVERAGE=1 ..."
+        unless scalar @tests;
     @tests_unit = grep { /^t\// } map { $_ =~ s/ ^ core\/server\/ //x; $_ } @tests;
     @tests_qa   = grep { /^qatest\// } @tests;
 }
@@ -103,14 +105,14 @@ my $is_local_repo = 0;
 # remote repo as specified
 if ($ENV{OXI_TEST_GITREPO}) {
     $repo = $ENV{OXI_TEST_GITREPO};
-    _stop 100, "Sorry, local repositories specified by file:// are not supported:\n$repo"
+    _stop 100, "Sorry, local repositories specified by file:// are not supported.\nUse this instead:\ndocker run -v /my/host/path:/repo ..."
         if $repo =~ / \A file /msx;
 }
 # local repo from host (if Docker volume is mounted)
 else {
-    # check if /repo is a mountpoint (= dev number differs from parent dir)
-    _stop 101, "I need either a remote or local Git repo:\ndocker run -e OXI_TEST_GITREPO=https://...\ndocker run -v /my/path:/repo"
-        unless ((stat "/repo")[0]) != ((stat "/")[0]);
+    # only continue if /repo is a mountpoint (= device number differs from parent dir)
+    _stop 101, "Please specify either a remote or local Git repo:\ndocker run -e OXI_TEST_GITREPO=https://...\ndocker run -v /my/host/path:/repo"
+        if (not -d "/repo" or (stat "/repo")[0] == (stat "/")[0]);
     $repo = "file:///repo";
     $is_local_repo = 1;
 }

--- a/tools/docker-test/startup.pl
+++ b/tools/docker-test/startup.pl
@@ -198,10 +198,20 @@ if ($mode eq "coverage") {
     execute show => "cover -test";
     use DateTime;
     my $dirname = "code-coverage-".(DateTime->now->strftime('%Y%m%d-%H%M%S'));
-    move "./cover_db", "/repo/$dirname";
-    if (-d "/repo/$dirname") {
-        `chmod -R g+w,o+w "/repo/$dirname`;
-        print "\nCode coverage results available in project root dir:\n$dirname\n";
+    my $cover_src = "$clone_dir/core/server/cover_db";
+    my $cover_target = "/repo/$dirname";
+    if (-d $cover_src) {
+        system "mv", $cover_src, $cover_target;
+        if (-d $cover_target) {
+            `chmod -R g+w,o+w "$cover_target"`;
+            print "\nCode coverage results available in project root dir:\n$dirname\n";
+        }
+        else {
+            print "\nError: code coverage results could not be moved to host dir $cover_target:\n$!\n"
+        }
+    }
+    else {
+        print "\nError: code coverage results where not found\n($cover_src does not exist)\n"
     }
     exit;
 }

--- a/tools/docker-test/startup.pl
+++ b/tools/docker-test/startup.pl
@@ -93,7 +93,7 @@ elsif ($mode eq "selected") {
     my @tests = split /,/, $ENV{OXI_TEST_ONLY};
     _stop 105, "Please specify one of the following variables:\ndocker run -e OXI_TEST_ALL=1 ...\ndocker run -e OXI_TEST_ONLY=relpath/to/test1.t,relpath/dir ...\ndocker run -e OXI_TEST_COVERAGE=1 ..."
         unless scalar @tests;
-    @tests_unit = grep { /^t\// } map { $_ =~ s/ ^ core\/server\/ //x; $_ } @tests;
+    @tests_unit = grep { /^t\// } map { my $t = $_; $t =~ s/ ^ core\/server\/ //x; $t } @tests;
     @tests_qa   = grep { /^qatest\// } @tests;
 }
 
@@ -256,5 +256,5 @@ execute show => "/usr/local/bin/openxpkictl start";
 #
 print "\n====[ Testing: QA tests ]====\n";
 chdir "$clone_dir/qatest";
-my @t = map { $_ =~ s/ ^ qatest\/ //x; $_ } @tests_qa;
+my @t = map { my $t = $_; $t =~ s/ ^ qatest\/ //x; $t } @tests_qa;
 execute show => "prove -l -r -q $_" for @t;

--- a/vagrant/develop/assets/provision.sh
+++ b/vagrant/develop/assets/provision.sh
@@ -156,33 +156,8 @@ if [ -e /etc/logrotate.d/ ]; then
     cp /code-repo/config/logrotate.conf /etc/logrotate.d/openxpki
 fi
 
-# CONFIGURATION
-
-rsync -a /code-repo/config/openxpki/* /etc/openxpki/                  >$LOG 2>&1
-chmod 750              /etc/openxpki/config.d
-chmod 750              /etc/openxpki/ssl/
-chown -R openxpki:root /etc/openxpki/config.d
-chown -R openxpki:root /etc/openxpki/ssl/
-
-# DATABASE SETUP
-
-cat <<__DB > /etc/openxpki/config.d/system/database.yaml
-main:
-    debug: 0
-    type: MySQL
-    host: $OXI_TEST_DB_MYSQL_DBHOST
-    port: $OXI_TEST_DB_MYSQL_DBPORT
-    name: $OXI_TEST_DB_MYSQL_NAME
-    user: $OXI_TEST_DB_MYSQL_USER
-    passwd: $OXI_TEST_DB_MYSQL_PASSWORD
-__DB
-
-/bin/bash /vagrant/scripts/oxi-refresh --no-restart              2>&1 | tee $LOG
-
-rm -rf /etc/openxpki/ssl/
-/code-repo/config/sampleconfig.sh                                     >$LOG 2>&1
-
-openxpkictl start                                                     >$LOG 2>&1
+# CONFIGURATION and DATABASE SETUP
+/bin/bash /vagrant/scripts/oxi-refresh --full                    2>&1 | tee $LOG
 
 #
 # Apache configuration

--- a/vagrant/develop/scripts/oxi-refresh
+++ b/vagrant/develop/scripts/oxi-refresh
@@ -1,5 +1,5 @@
 #!/bin/bash
-## <info> Copy latest code from /code-repo, compile, install dependencies, restart OpenXPKI
+## <info> Copy code from host, configure, compile, install dependencies, restart OpenXPKI
 test $(whoami) != "root" && echo "Please run this as root: sudo $0" && exit 1
 set -o pipefail
 
@@ -9,14 +9,55 @@ set -o pipefail
 LOG=$(mktemp)
 function _exit () {
     if [ $1 -ne 0 -a $1 -ne 333 ]; then
-        echo "$0: ERROR - last command exited with code $1, output:" && cat $LOG
+        echo "================================================================================"
+        echo "$0: ERROR - last command exited with code $1, output:"
+        echo "================================================================================"
+        cat $LOG
     fi
     rm -f $LOG
     exit $1
 }
-trap '_exit $?' EXIT
 
+[[ "${@#--help}" != "$@" ]] && cat <<__HELP && exit 1
+SYNOPSIS
+    $(basename "$0") [OPTIONS]
+
+DESCRIPTION
+    $(cat "$0" | grep "[[:blank:]]#*[[:blank:]]*<info>" | cut -d ">" -f2 | sed s/'^[[:blank:]]*'//)
+
+OPTIONS
+    --no-restart
+        Skip restarting OpenXPKI and Apache.
+
+    --no-i18n
+        Skip updating internationalization files.
+
+    --no-compile
+        Skip compiling XS code parts.
+
+    --fast
+        Shortcut for "--no-i18n --no-compile"
+
+    --full
+        Overwrite /etc/openxpki with slightly adjusted sample config
+__HELP
+
+trap '_exit $?' EXIT
 set -e
+
+#
+# Command line options
+#
+IS_I18N=1
+IS_RESTART=1
+IS_COMPILE=1
+IS_FULLCONFIG=0
+# Bash string manipulation: use # to strip text off $@ and see if string still equals original $@
+[[ "${@#--no-i18n}" != "$@" ]]    && IS_I18N=0
+[[ "${@#--no-restart}" != "$@" ]] && IS_RESTART=0
+[[ "${@#--no-compile}" != "$@" ]] && IS_COMPILE=0
+[[ "${@#--fast}" != "$@" ]]       && IS_COMPILE=0 && IS_I18N=0
+[[ "${@#--full}" != "$@" ]]       && IS_FULLCONFIG=1
 
 #
 # Grab and install Perl module dependencies from Makefile.PL using PPI
@@ -25,7 +66,7 @@ set -e
 rm -f /usr/lib/x86_64-linux-gnu/perl5/5.20/Net/DNS.pm
 cpanm --notest Net::DNS                                               >$LOG 2>&1
 
-echo "Checking for new Perl dependencies in latest code"
+echo "Checking and installing Perl module dependencies"
 cpanm --notest PPI                                                    >$LOG 2>&1
 /code-repo/tools/scripts/makefile2cpanfile.pl > /cpanfile
 cpanm --quiet --notest --installdeps /
@@ -33,18 +74,37 @@ cpanm --quiet --notest --installdeps /
 #
 # Copy current code and realm CA-ONE config
 #
-echo "Copying current code and binaries from repo"
+echo ""
 
-rsync -a --delete /code-repo/core/server/cgi-bin/* /usr/lib/cgi-bin/           >$LOG 2>&1
-rsync -a --delete /code-repo/core/server/htdocs/*  /var/www/openxpki/          >$LOG 2>&1
-test -e /var/www/openxpki/index.html || ln -s default.html /var/www/openxpki/index.html
+# fully overwrite existing config
+if [[ $IS_FULLCONFIG -eq 1 ]]; then
+    echo "Writing complete OpenXPKI config into /etc/openxpki"
+    rsync -a --delete /code-repo/config/openxpki/* /etc/openxpki/     >$LOG 2>&1
+    chmod 750              /etc/openxpki/config.d
+    chown -R root:openxpki /etc/openxpki/config.d
 
-rsync -a --delete \
-  /code-repo/config/openxpki/config.d/realm/ca-one/* \
-  /etc/openxpki/config.d/realm/ca-one/                                >$LOG 2>&1
-chown -R openxpki:root /etc/openxpki/config.d/realm/ca-one            >$LOG 2>&1
+    # database setup
+    echo "- configuring MySQL as database"
+    cat <<__DB > /etc/openxpki/config.d/system/database.yaml
+    main:
+        debug: 0
+        type: MySQL
+        host: $OXI_TEST_DB_MYSQL_DBHOST
+        port: $OXI_TEST_DB_MYSQL_DBPORT
+        name: $OXI_TEST_DB_MYSQL_NAME
+        user: $OXI_TEST_DB_MYSQL_USER
+        passwd: $OXI_TEST_DB_MYSQL_PASSWORD
+__DB
+# only partial config update (only realm ca-one)
+else
+    echo "Updating realm CA-ONE in /etc/openxpki/config.d/realm/ca-one"
+    rsync -a --delete \
+      /code-repo/config/openxpki/config.d/realm/ca-one/* \
+      /etc/openxpki/config.d/realm/ca-one/                            >$LOG 2>&1
+    chown -R root:openxpki /etc/openxpki/config.d/realm/ca-one        >$LOG 2>&1
+fi
 
-echo "Modifying some config entries"
+echo "- modifying some config entries"
 
 # set /var/tmp instead of /tmp (where only root has write access)
 sed -ri 's/(LOCATION:)\s*\/tmp.*/\1 \/var\/tmp/g' /etc/openxpki/config.d/realm/ca-one/publishing.yaml
@@ -55,48 +115,57 @@ sed -ri 's/^(\s*default_language:).*/\1 en_US/' /etc/openxpki/config.d/system/se
 #
 # Compile OpenXPKI
 #
-OXI_VERSION=$(cat /code-repo/.VERSION_MAJOR <(echo .) /code-repo/.VERSION_MINOR <(echo .) /code-repo/.VERSION_RELEASE | tr -d "\n" )
+echo -e "\nCompilation and installation"
+echo -e "- synchronizing source code from host to $OXI_CORE_DIR"
+rsync -a --delete --exclude=.git/ /code-repo/core/                 $OXI_CORE_DIR      >$LOG 2>&1
+rsync -a --delete --exclude=.git/ /code-repo/core/server/cgi-bin/* /usr/lib/cgi-bin/  >$LOG 2>&1
+rsync -a --delete --exclude=.git/ /code-repo/core/server/htdocs/*  /var/www/openxpki/ >$LOG 2>&1
+test -e /var/www/openxpki/index.html || ln -s default.html /var/www/openxpki/index.html
 
 # Set version so Makefile.PL does not need "vergen" (which we will not copy to $OXI_CORE_DIR)
-cat <<__VERSION > /code-repo/core/server/OpenXPKI/VERSION.pm
+OXI_VERSION=$(cat /code-repo/.VERSION_MAJOR <(echo .) /code-repo/.VERSION_MINOR <(echo .) /code-repo/.VERSION_RELEASE | tr -d "\n" )
+cat <<__VERSION > $OXI_CORE_DIR/server/OpenXPKI/VERSION.pm
 package OpenXPKI::VERSION;
 our \$VERSION = '$OXI_VERSION';
 1;
 __VERSION
 
-echo "Synchronizing source code from host to $OXI_CORE_DIR"
-rsync -a --delete --exclude=.git/ /code-repo/core/ $OXI_CORE_DIR
-
-# if --fast is NOT given
 pushd $OXI_CORE_DIR/server                                            >$LOG 2>&1
 perl Makefile.PL                                                      >$LOG 2>&1
-if [[ "${@#--fast}" = "$@" ]]; then
-    echo "Compiling OpenXPKI $OXI_VERSION"
-    make                                                                  >$LOG 2>&1
+if [[ $IS_COMPILE -eq 1 ]]; then
+    echo "- compiling OpenXPKI $OXI_VERSION"
+    make                                                              >$LOG 2>&1
 fi
-echo "Installing OpenXPKI"
+echo "- installing OpenXPKI"
 make install                                                          >$LOG 2>&1
 popd                                                                  >$LOG 2>&1
 
-echo "Copying CGI::Session::Driver::openxpki"
+echo "- installing CGI::Session::Driver::openxpki"
 mkdir -p /usr/share/perl5/CGI/Session/Driver
 cp $OXI_CORE_DIR/server/CGI_Session_Driver/openxpki.pm /usr/share/perl5/CGI/Session/Driver/
 
-# if --no-i18n and --fast are NOT given
-# (use # to strip text off $@ and see if string still equals original $@)
-if [[ "${@#--no-i18n}" = "$@" && "${@#--fast}" = "$@" ]]; then
-    echo "Compiling and installing I18N files"
+if [[ $IS_I18N -eq 1 ]]; then
+    echo "- compiling and installing I18N files"
     echo "$OXI_VERSION" > $OXI_CORE_DIR/i18n/VERSION
-    pushd $OXI_CORE_DIR/i18n                                              >$LOG 2>&1
+    pushd $OXI_CORE_DIR/i18n                                          >$LOG 2>&1
     langs=$(grep '^LANGS\s*=' Makefile | cut -d= -f2)
     for lang in $langs; do msgfmt -o $lang/openxpki.mo $lang/openxpki.po; done
-    make install                                                          >$LOG 2>&1
-    popd                                                                  >$LOG 2>&1
+    make install                                                      >$LOG 2>&1
+    popd                                                              >$LOG 2>&1
 fi
 
-# if --no-restart and --fast are NOT given
-if [[ "${@#--no-restart}" = "$@" && "${@#--fast}" = "$@" ]]; then
-    echo "Restarting OpenXPKI"
+# create SSL keys and certificates and import them into OpenXPKI
+if [[ $IS_FULLCONFIG -eq 1 ]]; then
+    echo -e "\nCreating and importing sample certificates"
+    rm -rf /etc/openxpki/ssl/
+    /code-repo/config/sampleconfig.sh                                 >$LOG 2>&1
+    chmod 750              /etc/openxpki/ssl
+    chown -R root:openxpki /etc/openxpki/ssl
+fi
+
+if [[ $IS_RESTART -eq 1 ]]; then
+    echo -e "\nRestart"
+    echo "- OpenXPKI"
     openxpkictl restart                                               >$LOG 2>&1
 
     if [[ $(openxpkictl status 2>&1) == *"not running"* ]]; then
@@ -104,6 +173,8 @@ if [[ "${@#--no-restart}" = "$@" && "${@#--fast}" = "$@" ]]; then
         exit 333
     fi
 
-    echo "Restarting Apache"
+    echo "- Apache"
     systemctl restart apache2                                         >$LOG 2>&1
 fi
+
+echo -e "\nDone."


### PR DESCRIPTION
The Docker test container will now run all tests by default, e.g.:
`docker run -ti --rm -v ~/prj/openxpki:/repo oxi-test`

It's also possible to open a shell:
`docker run -ti --rm oxi-test bash`
