### PR TITLE
Introduce documentation for PKCS#11 and improve documentation for Authentication

### DIFF
--- a/doc/reference/configuration/realm.rst
+++ b/doc/reference/configuration/realm.rst
@@ -36,15 +36,17 @@ Authentication is done via authentication handlers, multiple handlers are combin
 Stack
 ^^^^^
 
-The authentication stacks are set below ``auth.stack``::
+The realm's authentication combines the configured authentication handlers to offer different authentication stacks. On the login page, the entries of the stack are shown and a user can choose between them. The stacks are configured in the file located in ``<realm-basedir>/auth/stack.yaml``. If, for example, one would like to enable only anonymous logins and password based logins, this file's contents could be as follows::
 
-    User:
-        description: I18N_OPENXPKI_CONFIG_AUTH_STACK_DESCRIPTION_USER
-        handler:
-        - User Password
-        - Operator Password
+   Anonymous:
+      handler: Anonymous
 
-The code above defines a stack *User* which internally uses two handlers for authentication. You can define any number of stacks and reuse the same handlers inside. You must define at least one stack.
+   User:
+      handler:
+          - Operator Password
+          - User Password
+
+In this configuration, the realm offers two login stacks, namely *Anonymous* and *Operator*. The stack *Anonymous*  uses the Handler_ ``Anonymous`` and the logins using the stack *User* may be performed by both handlers ``Operator Password`` and ``User Password``. Therefore, when selecting this variant, both logins with credentials configured for  ``Operator Password`` and for ``User Password`` are supported. You can define any number of stacks and reuse the same handlers inside. You must define at least one stack.
 
 
 Handler
@@ -54,7 +56,7 @@ A handler consists of a perl module, that provides the authentication mechanism.
 
 Here is a list of the default handlers and their configuration sets.
 
-**anonymous user**
+**Anonymous user**
 
 If you just need an anonymous connection, you can use the *Anonymous* handler. ::
 
@@ -99,7 +101,7 @@ Both lists can be combined and accept any number of items.
 
 **Note**: OpenXPKI uses a third party tool named openca-sv to check the x509 signature. You need to build that by your own and put it into /usr/bin. The source is available at http://www.openca.org/projects/openca/tools-sources.shtml.
 
-**password database handler**
+**Password database handler**
 
 The password database handler allows to specify user/password/role pairs directly inside the configuration. ::
 
@@ -118,7 +120,11 @@ The password database handler allows to specify user/password/role pairs directl
                 digest: "{SSHA}ejZpY22dFwjVI48z14y2jYuToPRjOXRP"
                 role: RA Operator
 
-The passwords are hashed, the used hash algorithm is given as prefix inside the curly brackets. You should use only *SSHA* which is "salted sha1". For compatibility we support plain sha (sha1), md5, smd5 (salted md5) and crypt. You can created the salted passwords using the openxpkiadm CLI tool.
+The passwords are hashed, the used hash algorithm is given as prefix inside the curly brackets. You should use only *SSHA* which is "salted sha1". For compatibility we support plain sha (sha1), md5, smd5 (salted md5) and crypt. You can created the salted passwords using the openxpkiadm CLI tool (``openxpkiadm hashpwd``). Alternatively, for batch processing, a *salted sha1* password could be generated using openssl::
+
+   salt="$(openssl rand -base64 3 | openssl enc -base64)"
+   password="secretpassword"
+   echo -n $(echo -n "$password$salt" | openssl sha1 -binary)$salt | openssl enc -base64
 
 If you plan to use static passwords for a larger amount of users, you should consider to use a connector instead::
 
@@ -145,7 +151,7 @@ The user file has the same structure as the *user* section above, the user names
 
 You can share a user database file within realms.
 
-**authentication connectors**
+**Authentication connectors**
 
 There is a family of authentication connectors. The main difference against
 other connector is, that the password is passed as a parameter and is not
@@ -171,7 +177,7 @@ An example config to authenticate RA Operators against ActiveDirectory using the
         filter: "(&(mail=[% LOGIN %])(memberOf=CN=RA Operator,OU=SecurityGroups,DC=company,DC=loc))"
 
 
-**external authentication**
+**External authentication**
 
 If you have a proxy or sso system in front of your OpenXPKI server that authenticates your users, the external handler can be used to set the user information::
 

--- a/doc/reference/configuration/realm.rst
+++ b/doc/reference/configuration/realm.rst
@@ -405,6 +405,7 @@ To use PKCS#11 tokens in OpenXPKI, the backend of the token has to be set to *PK
        key_store: ENGINE
        shell: /usr/bin/openssl
        randfile: /var/openxpki/rand
+       wrapper: ''
        secret: signer
 
 The linked secret is only used to get access to the HSM.


### PR DESCRIPTION
I managed to configure the YubiHSM2 in OpenXPKI as a keystore and wrote some docs how this can be done.
Furthermore, when configuring the authentication it took me a while to understand how the stack.yaml and the handler.yaml work, so I tried to clarify this in the docs.