### PR TITLE
Fix CheckDNS requests by increasing tries from 0 to 1

### DIFF
--- a/core/server/OpenXPKI/Template/Plugin/CheckDNS.pm
+++ b/core/server/OpenXPKI/Template/Plugin/CheckDNS.pm
@@ -89,7 +89,7 @@ sub _init_dns {
     my $rr = Net::DNS::Resolver->new();
     $rr->udp_timeout($self->timeout());
     $rr->tcp_timeout($self->timeout());
-    $rr->retry(0);
+    $rr->retry(1);
     # the resolver waits for retrans even if a timeout occured
     $rr->retrans($self->timeout());
 


### PR DESCRIPTION
Back in 7588c6f70e22e965364e3a614dffd79dc6745db6 retry() has been set to 1 in [one case](https://github.com/openxpki/openxpki/commit/7588c6f70e22e965364e3a614dffd79dc6745db6#diff-261de957529fc5f25362f52499eef70bR71) and 0 in [the other](https://github.com/openxpki/openxpki/commit/7588c6f70e22e965364e3a614dffd79dc6745db6#diff-021a32e2225efb9b2a29cddcd74f9d29R83).

retry() seems to define the total amount of DNS requests made though. As far as I understand the NetDNS code, setting it to 0 causes no request being made at all.

The problem has been described in [this mailing thread](https://sourceforge.net/p/openxpki/mailman/openxpki-users/thread/394f0ba680f04e8c908959aa6b6a93b1%40EX2013-DB01.adesso.local/#msg36669362).