### PR TITLE
Add support for STARTTLS when connecting to SMTP servers.

### DIFF
--- a/core/server/OpenXPKI/Server/Notification/SMTP.pm
+++ b/core/server/OpenXPKI/Server/Notification/SMTP.pm
@@ -15,6 +15,7 @@ are read from the filesystem.
         host: localhost
         helo: my.own.fqdn
         port: 25
+        starttls: 0
         username: smtpuser
         password: smtppass
         debug: 0
@@ -196,6 +197,10 @@ sub _init_transport {
     if (!$transport || !ref $transport) {
         CTX('log')->system()->fatal(sprintf("Failed creating smtp transport (host: %s, user: %s)", $smtp{Host}, $smtp{User}));
         return undef;
+    }
+
+    if($cfg->{starttls}) {
+        $transport->starttls;
     }
 
     if($cfg->{username}) {

--- a/core/server/t/config.d/realm/I18N_OPENXPKI_DEPLOYMENT_TEST_DUMMY_CA/notification.yaml
+++ b/core/server/t/config.d/realm/I18N_OPENXPKI_DEPLOYMENT_TEST_DUMMY_CA/notification.yaml
@@ -84,6 +84,7 @@ smtp:
         class: OpenXPKI::Server::Notification::SMTP
         host: localhost
         port: 25
+        starttls: 0
         username: ~
         password: ~
         debug: 0

--- a/doc/reference/configuration/realm.rst
+++ b/doc/reference/configuration/realm.rst
@@ -584,6 +584,7 @@ You first need to configure the SMTP backend parameters::
         class: OpenXPKI::Server::Notification::SMTP
         host: localhost
         port: 25
+        starttls: 0
         username: smtpuser
         password: smtpsecret
         debug: 0


### PR DESCRIPTION
Net::SMTP already supports this feature for a long time now.
This simple patch allows notifications to be sent on SMTP servers that require TLS transport prior to any further interaction (tested on debian 10).