### PR TITLE
Fixed renewing of certificates with dirName in their SAN

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Authors:
 * Shota Okuhara
 * Paweł Tomulik
 * Tomoyuki Kamo
+* Zdeněk Biberle

--- a/core/server/OpenXPKI/Server/NICE.pm
+++ b/core/server/OpenXPKI/Server/NICE.pm
@@ -177,16 +177,16 @@ sub __persistCertificateInformation {
     );
 
 
-    my @parsed_subject_alt_names = @{$x509->get_subject_alt_name()};
-    ##! 32: 'sans (parsed): ' . Dumper \@parsed_subject_alt_names
-    for my $san (@parsed_subject_alt_names) {
+    my @structured_subject_alt_names = @{$x509->get_structured_subject_alt_name()};
+    ##! 32: 'sans (structured): ' . Dumper \@structured_subject_alt_names
+    for my $san (@structured_subject_alt_names) {
         CTX('dbi')->insert(
             into => 'certificate_attributes',
             values => {
                 attribute_key        => AUTO_ID,
                 identifier           => $identifier,
                 attribute_contentkey => 'subject_alt_name',
-                attribute_value      => join(":", @$san),
+                attribute_value      => $serializer->serialize($san),
             },
         );
     }

--- a/core/server/OpenXPKI/Server/Workflow/Activity/Tools/PrepareRenewal.pm
+++ b/core/server/OpenXPKI/Server/Workflow/Activity/Tools/PrepareRenewal.pm
@@ -55,8 +55,15 @@ sub execute {
 
     my @subject_alt_names;
     while (my $san = $sth->fetchrow_hashref) {
-        my @split = split q{:}, $san->{attribute_value};
-        push @subject_alt_names, \@split;
+        # If the value is serialized, deserialize it. If it's not, assume
+        # that it is stored in the old colon-separated form and parse
+        # it manually.
+        if (OpenXPKI::Serialization::Simple::is_serialized($san->{attribute_value})) {
+            push @subject_alt_names, $serializer->deserialize($san->{attribute_value});
+        } else {
+            my @split = split q{:}, $san->{attribute_value};
+            push @subject_alt_names, \@split;
+        }
     }
     ##! 64: 'subject_alt_names: ' . Dumper(\@subject_alt_names)
     $context->param(  $prefix.'cert_subject_alt_name' =>

--- a/core/server/t/25_crypto/36_object_x509.t
+++ b/core/server/t/25_crypto/36_object_x509.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+use Test::More;
+
+plan tests => 8;
+
+use_ok "OpenXPKI::Crypt::X509";
+
+## define a test object
+my $example_certificate = '-----BEGIN CERTIFICATE-----
+MIIB6jCCAZGgAwIBAgIUAzOGaDL9MVh6C+YChqwrQmKDm04wCgYIKoZIzj0EAwIw
+HjEcMBoGA1UEAwwTRXhhbXBsZSBjZXJ0aWZpY2F0ZTAeFw0yMDA0MTcxMzI5Mjda
+Fw0yMDA1MTcxMzI5MjdaMB4xHDAaBgNVBAMME0V4YW1wbGUgY2VydGlmaWNhdGUw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARt47IstyihcXvZgJpyO7UzDkP73z6l
+6MFwznfFSN0aFCnxYWWWJqlu7eV/weKsS9oG/K136U2YoaXBqHQ4fETno4GsMIGp
+MIGmBgNVHREEgZ4wgZukXTBbMQswCQYDVQQGEwJVUzEuMA0GA1UECgwGQmFyT3Jn
+MA0GA1UECgwGRm9vT3JnMA4GA1UECwwHQmF6VW5pdDEcMBoGA1UEAwwTRXhhbXBs
+ZSBjb21tb24gbmFtZYIPZG5zLmV4YW1wbGUuY29tgRFlbWFpbEBleGFtcGxlLmNv
+bYcE20F1jocQcEYrOeMjiycv73JsEZeafjAKBggqhkjOPQQDAgNHADBEAiB8nyFx
+/o3yY6GTMjGu3PpSaPS6J+6IvsprqR7ELWvJIQIgAZgxJuOg1egVzArsxWBMATbt
+40ogDLlti/K+xBB886Y=
+-----END CERTIFICATE-----';
+
+## test object creation
+my $x509 = OpenXPKI::Crypt::X509->new($example_certificate);
+ok(1, 'certificate parsed');
+
+is($x509->pem, $example_certificate, 'certificate has not been mangled in any way');
+is($x509->get_subject, 'CN=Example certificate', 'subject is as expected');
+is_deeply($x509->get_structured_subject_alt_name,
+    [
+        [ 
+            'dirName',
+            {
+                rdnSequence => [
+                    [
+                        {
+                            value => { printableString => 'US' },
+                            type => '2.5.4.6'
+                        }
+                    ],
+                    [
+                        {
+                            value => { utf8String => 'BarOrg' },
+                            type => '2.5.4.10'
+                        },
+                        {
+                            type => '2.5.4.10',
+                            value => { utf8String => 'FooOrg' }
+                        },
+                        {
+                            type => '2.5.4.11',
+                            value => { utf8String => 'BazUnit' }
+                        }
+                    ],
+                    [
+                        {
+                            type => '2.5.4.3',
+                            value => { utf8String => 'Example common name' }
+                        }
+                    ]
+                ]
+            }
+        ],
+        [ 'DNS', 'dns.example.com' ],
+        [ 'email', 'email@example.com' ],
+        [ 'IP', "\xdb\x41\x75\x8e" ],
+        [ 'IP', "\x70\x46\x2b\x39\xe3\x23\x8b\x27\x2f\xef\x72\x6c\x11\x97\x9a\x7e" ]
+    ],
+    'SAN is as expected');
+is($x509->notbefore, 1587130167, 'not before is as expected');
+is($x509->notafter, 1589722167, 'not after is as expected');
+is($x509->get_serial, '18276018821053647745944141854221156918868810574', 'serial is as expected');
+
+1;


### PR DESCRIPTION
This fixes https://github.com/openxpki/openxpki/issues/747 by storing the full representation of the original certificate's SANs in the database and then using that to generate the OpenSSL config.

To do that, it requires the changes in https://github.com/openxpki/Crypt-X509/pull/1.

Note that this only fixes `dirName` as kind of a proof of concept, because the config generator has all kinds of other issues - such as not escaping anything properly and in general just using string concatenation to produce the config file without much structure to it. I think that should be fixed first (perhaps by using a proper library for writing INI files? Though I'm not sure if the OpenSSL config is an exact INI file, that might need some investigation).

However, to properly support other types of SANs, it shouldn't be necessary to change anything other than OpenXPKI::Crypto::Backend::OpenSSL::Config, so something like https://github.com/openxpki/openxpki/issues/642 should be easily fixable now.

The implementation should be backwards compatible, so renewing certificates that were issued before this change will work as well, even though the representation of their SANs in the database has changed.

I'm not much of a Perl programmer, so let me know if there's anything that can be improved.