### PR TITLE
Accept 'undef' as valid page shortlabel

### DIFF
--- a/core/server/OpenXPKI/Client/UI/Response/PageInfo.pm
+++ b/core/server/OpenXPKI/Client/UI/Response/PageInfo.pm
@@ -8,7 +8,7 @@ has 'label' => (
 
 has 'shortlabel' => (
     is => 'rw',
-    isa => 'Str',
+    isa => 'Str|Undef',
 );
 
 has 'description' => (


### PR DESCRIPTION
Our Cisco SCEP Requests only make use of the subject attributes unstructuredAddress, unstructuredName and OU. When trying to view a certificate on the WebUI, the popup trys to set the CN as shortlabel for the popup info. But since CN is not present we get a perl undef error.

```
2023/03/13 14:18:52 INF Attribute (shortlabel) does not pass the type constraint because: Validation failed for 'Str' with value undef at constructor OpenXPKI::Client::UI::Response::PageInfo::new (defined at /usr/share/perl5/OpenXPKI/Client/UI/Response/PageInfo.pm line 42) line 73
        OpenXPKI::Client::UI::Response::PageInfo::new('OpenXPKI::Client::UI::Response::PageInfo', 'label', 'Certificate Information', 'shortlabel', undef) called at /usr/share/perl5/OpenXPKI/Client/UI/Response.pm line 131
        OpenXPKI::Client::UI::Response::set_page('OpenXPKI::Client::UI::Response=HASH(0x561c64cd51c8)', 'label', 'Certificate Information', 'shortlabel', undef) called at inline delegation in OpenXPKI::Client::UI::Result for resp->set_page (attribute declared in /usr/share/perl5/OpenXPKI/Client/UI/Result.pm at line 221) line 18
        OpenXPKI::Client::UI::Result::set_page('OpenXPKI::Client::UI::Certificate=HASH(0x561c650afc10)', 'label', 'Certificate Information', 'shortlabel', undef) called at /usr/share/perl5/OpenXPKI/Client/UI/Certificate.pm line 623
        OpenXPKI::Client::UI::Certificate::init_detail('OpenXPKI::Client::UI::Certificate=HASH(0x561c650afc10)') called at /usr/share/perl5/OpenXPKI/Client/UI.pm line 483
        OpenXPKI::Client::UI::handle_page('OpenXPKI::Client::UI=HASH(0x561c6503b5a8)', 'HASH(0x561c6509e2a8)') called at /usr/share/perl5/OpenXPKI/Client/UI.pm line 244
        OpenXPKI::Client::UI::handle_request('OpenXPKI::Client::UI=HASH(0x561c6503b5a8)', 'OpenXPKI::Client::UI::Request=HASH(0x561c64d0aaf8)') called at /usr/lib/cgi-bin/webui.fcgi line 289
        eval {...} at /usr/lib/cgi-bin/webui.fcgi line 270
```

The commit is similar to a previous fix from november: 744f03c80657bd058dcc64d52f52af92c991c661