### PR TITLE
add unstructured oids to new mapper

### DIFF
--- a/core/server/OpenXPKI/DN.pm
+++ b/core/server/OpenXPKI/DN.pm
@@ -34,6 +34,8 @@ my %mapping_of = (
     PSEUDONYM            => "pseudonym",
     ROLE                 => "role",
     DESCRIPTION          => "description",
+    UNSTRUCTUREDNAME     => "unstructuredName",
+    UNSTRUCTUREDADDRESS  => "unstructuredAddress",
     );
 
 sub new

--- a/core/server/OpenXPKI/Role/SubjectOID.pm
+++ b/core/server/OpenXPKI/Role/SubjectOID.pm
@@ -27,6 +27,8 @@ sub __build_subject_oid_map {
         "2.5.4.10"                      => ['O','organizationName'],
         "2.5.4.11"                      => ['OU','organizationalUnitName'],
         "1.2.840.113549.1.9.1"          => ["emailAddress","E"],
+        "1.2.840.113549.1.9.2"          => 'unstructuredName',
+        "1.2.840.113549.1.9.8"          => 'unstructuredAddress',
         "0.9.2342.19200300.100.1.1"     => ['UID','userID'],
         "0.9.2342.19200300.100.1.25"    => ['DC','domainComponent'],
         '2.5.4.12'                      => [ 'title', 'Title' ],


### PR DESCRIPTION
Those attributes are missing in the new written mapper. Problems have already been discussed on the mailinglist: https://sourceforge.net/p/openxpki/mailman/openxpki-users/thread/4db4d09db965e322ab5581fc06696aaa%40dotlan.net/

I've tested the changes already and it seems to work.