### PR TITLE
Fix systemd unit packaging for debian

### DIFF
--- a/package/debian/core/rules
+++ b/package/debian/core/rules
@@ -63,6 +63,7 @@ install-stamp: build
 	$(MAKE) install PREFIX=$(CURDIR)/debian/libopenxpki-perl/usr
 	dh_makeshlibs
 	dh_installinit --no-start --noscripts --name=openxpkid
+	dh_installsystemd --no-start --name=openxpkid
 	touch install-stamp
 
 .PHONY: arrange binary binary-arch binary-indep build clean config install


### PR DESCRIPTION
This should fix the packaging issue #883 where the openxpkid.service file is no longer included in the resulting debian package.

Packaging tested in a Debian buster (which was named to have a problem) container and examined the contents of the .deb file afterwords. I haven't done a test installation yet, but the systemd unit is included again.

```
root@66a41ca10054:/openxpki/package/debian# dpkg -c deb/core/libopenxpki-perl_3.26.0-0_amd64.deb  | grep service
-rw-r--r-- root/root       647 2023-09-27 21:11 ./lib/systemd/system/openxpkid.service
```

