### PR TITLE
Fix sudoers syntax in debian.postinst, use full path

### DIFF
--- a/package/debian/core/libopenxpki-perl.postinst
+++ b/package/debian/core/libopenxpki-perl.postinst
@@ -117,7 +117,7 @@ case "$1" in
 
         # Create the sudo file to restart oxi from pkiadm
         if [ ! -e /etc/sudoers.d/pkiadm ] && [ -d /etc/sudoers.d ]; then
-            echo "pkiadm ALL=(ALL) NOPASSWD:service openxpkid" > /etc/sudoers.d/pkiadm
+            echo "pkiadm ALL=(ALL) NOPASSWD:/usr/sbin/service openxpkid" > /etc/sudoers.d/pkiadm
         fi;
 
         if [ -e "/var/openxpki/openxpki.socket" ]; then


### PR DESCRIPTION
Sudoers expects a fully-qualified path name and displays a warning on a fresh debian12 installation when using `sudo`.

```
/etc/sudoers.d/pkiadm:2:27: expected a fully-qualified path name
pkiadm ALL=(ALL) NOPASSWD:service openxpkid
                          ^~~~~~~
```