### PR TITLE
Fix EST enrolment creating new workflows for same CSR

### DIFF
--- a/core/server/OpenXPKI/Client/Service/Role/Base.pm
+++ b/core/server/OpenXPKI/Client/Service/Role/Base.pm
@@ -1034,7 +1034,9 @@ sub pickup_request ($self, $pickup_config, $wf_type) {
         $pickup_keys ||= $pickup_attribute;
 
         # run pickup
-        $wf_id = $self->pickup_via_attribute($wf_type, $pickup_attribute, $self->request_param($pickup_keys));
+        # use wf_params to fetch attribute value, as request_param may be unset in workflow context
+        $wf_id = $self->pickup_via_attribute($wf_type, $pickup_attribute, $self->wf_params->{$pickup_keys});
+
     }
     # only if pickup was done at all and did not die
     if ($wf_id) {


### PR DESCRIPTION
For the default 'democa' configuration using EST, a new workflow is always created if the same CSR is submitted multiple times.

Without this fix, the system fails to match the existing workflow due to an empty pickup value:

2025/06/12 22:15:57 DEB Ignoring pickup via attribute: empty pickup value
2025/06/12 22:15:57 DEB Initialize workflow 'certificate_enroll' with parameters: ...

With the fix, the CSR is correctly matched by its transaction ID:

2025/06/12 22:19:18 DEB Pickup via attribute: transaction_id = 8bf974bdc5e3bad61178218742a4b81a1107885a

The bug was due to pickup_request using request_param(...), which returns undef in workflow context. Switched to wf_params->{...} for correct behavior.