### PR TITLE
Fix debian packaging after systemd unit rename

### DIFF
--- a/package/debian/core/rules
+++ b/package/debian/core/rules
@@ -62,7 +62,7 @@ install-stamp: build
 	dh_installdirs
 	$(MAKE) install PREFIX=$(CURDIR)/debian/libopenxpki-perl/usr
 	dh_makeshlibs
-	dh_installsystemd --no-start --no-enable --name=openxpkid
+	dh_installsystemd --no-start --no-enable --name=openxpki-serverd
 	dh_installsystemd --no-start --no-enable --name=openxpki-clientd
 	touch install-stamp
 


### PR DESCRIPTION
After the rename of the openxpkid unit to openxpki-serverd, the rename of the `dh_installsystemd` argument was missing.

In the current debian package, the server unit file is missing.