### PR TITLE
Add abiltiy to configure backend socket timeout to webui.fcgi

### DIFF
--- a/core/server/cgi-bin/webui.fcgi
+++ b/core/server/cgi-bin/webui.fcgi
@@ -177,7 +177,8 @@ while (my $cgi = CGI::Fast->new("")) {
         try {
             if (not $backend_client or not $backend_client->is_connected) {
                 $backend_client = OpenXPKI::Client->new(
-                    ($conf->{global}->{socket} ? (socketfile => $conf->{global}->{socket}) : ())
+                    ($conf->{global}->{socket} ? (socketfile => $conf->{global}->{socket}) : ()),
+                    ($conf->{global}->{backend_timeout} ? (timeout => $conf->{global}->{backend_timeout}) : ())
                 );
                 $backend_client->send_receive_service_msg('PING');
             }


### PR DESCRIPTION
With slow crypto modules, the presentation of the system status with multiple signer certificates, which needs to be checked for their status, can take quite some time and could lead to timeouts on the client side.

This change adds global.timeout configuration paramater to the old fcgi webui client similiar to the new OpenXPKI::Client.

As reference: the new frontend client
https://github.com/openxpki/openxpki/blob/develop/core/server/OpenXPKI/Client/Web.pm#L176-L179